### PR TITLE
Bug/improvements

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,11 +131,17 @@ jobs:
     - name: Pack
       if: github.event_name == 'workflow_dispatch'
       run: |
-        $versionArg = @()
+        $packArgs = @("--configuration", "Release", "--output", "./packages")
         if ("${{ github.event.inputs.version }}") {
-          $versionArg = @("-p:PackageVersion=${{ github.event.inputs.version }}")
+          # Override the assembly version AND the package version so they stay in lockstep.
+          # -p:Version must be applied at build time, so do NOT use --no-build here.
+          $packArgs += @("-p:Version=${{ github.event.inputs.version }}", "-p:PackageVersion=${{ github.event.inputs.version }}")
+        } else {
+          # No override: pack the already-built assemblies at the version centralized in
+          # src/Directory.Build.props.
+          $packArgs += "--no-build"
         }
-        dotnet pack WorkflowForge.sln --configuration Release --no-build --output ./packages @versionArg
+        dotnet pack WorkflowForge.sln @packArgs
 
     - name: Generate CycloneDX SBOM
       if: github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to WorkflowForge will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.1.2] - 2026-07-21
+
+### Fixed
+- **Resilience.Polly**: declared the transitive `Microsoft.Bcl.TimeProvider` (and `System.ComponentModel.Annotations`, `System.Threading.Tasks.Extensions`) dependencies so they flow to consumers. Previously the ILRepack-merged Polly referenced `Microsoft.Bcl.TimeProvider` but it was never declared in the package, causing a runtime `FileNotFoundException` (e.g. calling `UsePollyComprehensive` on .NET 8+).
+- **Observability.OpenTelemetry** and **Logging.Serilog**: fixed the same class of missing transitive dependency (`Microsoft.Extensions.*`, `System.Diagnostics.DiagnosticSource`, `System.Threading.Channels`) for their ILRepack-merged libraries.
+- **Observability.Performance**: `EnablePerformanceMonitoring()` / `GetPerformanceStatistics()` now work on standard foundries. Added `FoundryPerformanceStatistics`, `OperationStatistics`, and `PerformanceStatisticsMiddleware`; previously the API was a no-op (it required an interface nothing implemented) and always returned `null`.
+- **Core**: pooled foundries no longer leak `Properties` between executions; `WorkflowFoundry.Reset()` now clears per-execution state, preventing a stale operation index from crashing compensation on a subsequent (smaller) workflow.
+- **Audit**: audit entries now record the real workflow name from the foundry's current workflow instead of always `"Unknown"`.
+- **Core**: lifecycle-event subscribers throwing no longer mask the workflow's real exception or abort compensation mid-loop; `WorkflowSmith.Dispose()` iterates middleware under its lock; a check-then-act race that could leak a foundry on concurrent dispose is closed.
+- Guarded the ILRepack extensions so packing outside `Release` fails fast instead of shipping an unmerged package.
+
+### Changed
+- Package version and shared package metadata (`Copyright`, `PackageReleaseNotes`) are centralized in `src/Directory.Build.props`; all packages release under one version. The release workflow now overrides both `Version` and `PackageVersion` so assembly and package versions stay in lockstep.
+- Documentation corrected: performance-monitoring examples, false "dependency-free" claims on the Performance/Resilience extensions, and broken configuration-guide anchor links. Added `docs/RELEASING.md`.
+
 ## [2.1.1] - 2026-03-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.1.2] - 2026-07-21
 
 ### Fixed
-- **Resilience.Polly**: declared the transitive `Microsoft.Bcl.TimeProvider` (and `System.ComponentModel.Annotations`, `System.Threading.Tasks.Extensions`) dependencies so they flow to consumers. Previously the ILRepack-merged Polly referenced `Microsoft.Bcl.TimeProvider` but it was never declared in the package, causing a runtime `FileNotFoundException` (e.g. calling `UsePollyComprehensive` on .NET 8+).
+- **Resilience.Polly**: declared Polly's transitive dependencies (`Microsoft.Bcl.TimeProvider`, `Microsoft.Bcl.AsyncInterfaces`, `System.ComponentModel.Annotations`, `System.Threading.Tasks.Extensions`, and the `Microsoft.Extensions.DependencyInjection`/`Configuration` abstractions) so they flow to consumers. Previously the ILRepack-merged Polly referenced `Microsoft.Bcl.TimeProvider` but it was never declared in the package, causing a runtime `FileNotFoundException` (e.g. calling `UsePollyComprehensive` on .NET 8+).
 - **Observability.OpenTelemetry** and **Logging.Serilog**: fixed the same class of missing transitive dependency (`Microsoft.Extensions.*`, `System.Diagnostics.DiagnosticSource`, `System.Threading.Channels`) for their ILRepack-merged libraries.
 - **Observability.Performance**: `EnablePerformanceMonitoring()` / `GetPerformanceStatistics()` now work on standard foundries. Added `FoundryPerformanceStatistics`, `OperationStatistics`, and `PerformanceStatisticsMiddleware`; previously the API was a no-op (it required an interface nothing implemented) and always returned `null`.
 - **Core**: pooled foundries no longer leak `Properties` between executions; `WorkflowFoundry.Reset()` now clears per-execution state, preventing a stale operation index from crashing compensation on a subsequent (smaller) workflow.
 - **Audit**: audit entries now record the real workflow name from the foundry's current workflow instead of always `"Unknown"`.
 - **Core**: lifecycle-event subscribers throwing no longer mask the workflow's real exception or abort compensation mid-loop; `WorkflowSmith.Dispose()` iterates middleware under its lock; a check-then-act race that could leak a foundry on concurrent dispose is closed.
 - Guarded the ILRepack extensions so packing outside `Release` fails fast instead of shipping an unmerged package.
+- **Persistence**: suppressed the SonarAnalyzer `S4790` build error on the SHA1 used to derive snapshot keys (scoped `#pragma` with rationale); SHA1 here is a non-cryptographic key digest, and changing it would break existing persisted snapshot keys.
 
 ### Changed
 - Package version and shared package metadata (`Copyright`, `PackageReleaseNotes`) are centralized in `src/Directory.Build.props`; all packages release under one version. The release workflow now overrides both `Version` and `PackageVersion` so assembly and package versions stay in lockstep.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Workflow orchestration for .NET. The core package has no dependencies. Benchmarks show high workflow throughput, microsecond-scale operation latency, and modest steady-state allocation.
 
-**Version**: 2.1.1  
+**Version**: 2.1.2  
 **License**: MIT  
 **Compatibility**: .NET Standard 2.0
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,79 @@
+# Releasing WorkflowForge
+
+All packages (core + `WorkflowForge.Testing` + the 11 extensions) release together under a single
+version number. This document covers the prerequisites, the release checklist, the CI/CD pipeline
+walkthrough, artifact/attestation verification, and rollback.
+
+## Versioning model
+
+The version is centralized in **`src/Directory.Build.props`** (`<Version>`). Every packable project
+inherits it — there are no per-project `<Version>`/`<PackageVersion>` entries. `PackageVersion` is
+derived from `Version` unless explicitly overridden.
+
+The release workflow also accepts an optional `version` input (a `workflow_dispatch` parameter). When
+supplied it overrides **both** `Version` and `PackageVersion` at pack time (and rebuilds so the
+assembly version matches the package version). When omitted, the packages are packed at the version
+committed in `src/Directory.Build.props`.
+
+> Prefer bumping `src/Directory.Build.props` in a committed change and leaving the workflow input
+> empty — that keeps the source of truth in git. Use the input only for ad-hoc/out-of-band packs.
+
+## Prerequisites
+
+- Maintainer access to run the `Build and Test` workflow via **Run workflow** (`workflow_dispatch`).
+- Approval rights on the `nuget-publish` GitHub Environment (publishing is gated on human approval).
+- `NUGET_API_KEY` and `SONAR_TOKEN` configured as repository secrets.
+- A green `main` build (tests pass on `net48`, `net8.0`, `net10.0`).
+
+## Release checklist
+
+1. Decide the new version (SemVer).
+2. Update `<Version>` in `src/Directory.Build.props`.
+3. Update `CHANGELOG.md` (move items from *Unreleased* into the new version section).
+4. Update the version badge/number references in `README.md` if present.
+5. Commit and open a PR; merge once CI is green.
+6. Trigger the release: **Actions → Build and Test → Run workflow** on `main` (leave `version` empty
+   to use the committed version, or set it to override).
+7. Approve the `nuget-publish` environment when prompted.
+8. Verify the packages on NuGet.org and the attached build artifacts (below).
+
+## Pipeline walkthrough
+
+The `.github/workflows/build-test.yml` workflow, on `workflow_dispatch`:
+
+1. **Restore + Build + Test** in `Release` across `net8.0`, `net10.0`, and `net48`, with SonarCloud
+   analysis and coverage collection.
+2. **Pack** — `dotnet pack WorkflowForge.sln --configuration Release` into `./packages`. The three
+   ILRepack extensions (`Resilience.Polly`, `Observability.OpenTelemetry`, `Logging.Serilog`) merge
+   their third-party libraries during this Release build. (Packing in a non-Release configuration is
+   blocked by a guard target, because ILRepack only runs in Release.)
+3. **SBOM** — CycloneDX generates a JSON SBOM alongside the packages.
+4. **Provenance** — Sigstore build-provenance attestation is produced for the `.nupkg`, `.snupkg`,
+   and SBOM artifacts.
+5. **Publish** — gated by the `nuget-publish` environment (manual approval), then pushed to NuGet.org.
+
+## Verifying artifacts and attestation
+
+- Confirm every expected package is present in `./packages` (core + Testing + 11 extensions), all at
+  the same version, each with a matching `.snupkg`.
+- For the ILRepack packages, confirm the merged third-party assemblies are **not** shipped as separate
+  files and that required transitive dependencies (e.g. `Microsoft.Bcl.TimeProvider` for Polly) are
+  listed in the `.nuspec` `<dependencies>`.
+- Verify provenance with the GitHub CLI:
+
+  ```bash
+  gh attestation verify <package>.nupkg --repo animatlabs/workflow-forge
+  ```
+
+## Rollback
+
+NuGet packages cannot be deleted once published; they can only be **unlisted**. To roll back:
+
+1. Unlist the affected versions on NuGet.org (they remain restorable by exact version but disappear
+   from search/latest resolution).
+2. Fix forward: bump `<Version>` to a new patch, correct the issue, and run the release again.
+
+## Future signing options
+
+Author (certificate) signing of the `.nupkg` (in addition to the current Sigstore build-provenance
+attestation) can be added to the publish step when a code-signing certificate is available.

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -442,7 +442,7 @@ var workflow = WorkflowForge.CreateWorkflow("ResilientProcess")
 - `FixedIntervalStrategy` - Best for databases
 - `RandomIntervalStrategy` - Prevents thundering herd
 
-**Zero Dependencies**: Pure WorkflowForge extension with no external dependencies.  
+**Dependencies**: no third-party policy library — only WorkflowForge core plus small BCL polyfills (`System.Threading.Tasks.Extensions`, `System.ComponentModel.Annotations`).  
 **Configuration**: Programmatic only (via code). For `appsettings.json` support, use WorkflowForge.Extensions.Resilience.Polly.
 
 ### Polly Extension
@@ -535,7 +535,7 @@ foundry.UseValidation(
 await smith.ForgeAsync(workflow, foundry);
 ```
 
-**Dependencies**: DataAnnotations only; no extra third-party packages.
+**Dependencies**: BCL DataAnnotations plus `Microsoft.Extensions.*` (options/DI integration); no third-party validation library.
 
 ### Audit Extension
 
@@ -575,26 +575,22 @@ public class FileAuditProvider : IAuditProvider
     }
 }
 
-// Configure audit logging
+// Register the audit middleware on the foundry; it writes an entry per operation.
 var auditProvider = new FileAuditProvider("audit.log");
-var auditLogger = new AuditLogger(
+using var foundry = WorkflowForge.CreateFoundry("AuditedWorkflow");
+foundry.UseAudit(
     auditProvider,
-    userId: "user@example.com",
-    sessionId: Guid.NewGuid().ToString(),
-    timeProvider: new SystemTimeProvider());
-
-// Subscribe to events
-smith.WorkflowStarted += async (s, e) => 
-    await auditLogger.LogWorkflowStartedAsync(e);
-smith.WorkflowCompleted += async (s, e) => 
-    await auditLogger.LogWorkflowCompletedAsync(e);
-foundry.OperationCompleted += async (s, e) => 
-    await auditLogger.LogOperationCompletedAsync(e);
+    new AuditMiddlewareOptions { DetailLevel = AuditDetailLevel.Verbose },
+    initiatedBy: "user@example.com");
 
 await smith.ForgeAsync(workflow, foundry);
+
+// Or write a one-off custom entry directly:
+await foundry.WriteCustomAuditAsync(
+    auditProvider, "ManualCheckpoint", AuditEventType.Custom, "Completed");
 ```
 
-**Zero Dependencies**: Pure WorkflowForge extension. Implement `IAuditProvider` for your storage.
+**Dependencies**: `Microsoft.Extensions.*` (options/DI integration); no storage library — implement `IAuditProvider` for your backend.
 
 ### Persistence Extension
 
@@ -631,7 +627,7 @@ using var foundry = WorkflowForge.CreateFoundry("OrderProcessing");
 foundry.UsePersistence(provider);
 ```
 
-**Zero Dependencies**: Bring-your-own-storage pattern with no external dependencies.
+**Dependencies**: `Microsoft.Extensions.*` (options/DI integration); no storage library — bring your own via `IWorkflowPersistenceProvider`.
 
 ---
 

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -284,7 +284,8 @@ var foundry = WorkflowForge.CreateFoundry("ProcessOrder", logger, options: optio
 
 #### WorkflowForge.Extensions.Resilience
 
-Retry, breaker, timeout, and throttling without pulling in Polly.
+Retry with pluggable backoff strategies, without pulling in a third-party policy library. For circuit
+breakers, bulkheads, rate limiting, or stacked policies, use `WorkflowForge.Extensions.Resilience.Polly`.
 
 **Installation:**
 ```bash
@@ -292,14 +293,25 @@ dotnet add package WorkflowForge.Extensions.Resilience
 ```
 
 **Includes:**
-- Retry middleware
-- Circuit breaker
-- Timeouts
-- Simple rate limiting
+- Retry operations (`RetryWorkflowOperation`)
+- Backoff strategies: exponential, fixed interval, random (jitter)
+- `RetryPolicySettings` for attempt counts and delay bounds
 
 **Usage:**
 ```csharp
-// See package README for current API; base resilience is covered by Polly extension.
+using WorkflowForge.Extensions.Resilience;
+using WorkflowForge.Extensions.Resilience.Strategies;
+
+// Wrap an operation with exponential-backoff retry
+var resilientOperation = RetryWorkflowOperation.WithExponentialBackoff(
+    operation: myOperation,
+    baseDelay: TimeSpan.FromMilliseconds(100),
+    maxDelay: TimeSpan.FromSeconds(30),
+    maxAttempts: 3);
+
+var workflow = WorkflowForge.CreateWorkflow("ProcessOrder")
+    .AddOperation(resilientOperation)
+    .Build();
 ```
 
 #### WorkflowForge.Extensions.Resilience.Polly
@@ -498,8 +510,7 @@ Package: `WorkflowForge.Extensions.Persistence`
 
 ```csharp
 using WorkflowForge.Extensions; // UsePersistence
-using WorkflowForge.Extensions.Persistence.Abstractions; // IWorkflowPersistenceProvider
-using WorkflowForge.Extensions.Persistence.Abstractions; // WorkflowExecutionSnapshot
+using WorkflowForge.Extensions.Persistence.Abstractions; // IWorkflowPersistenceProvider, WorkflowExecutionSnapshot
 
 public sealed class MyPersistenceProvider : IWorkflowPersistenceProvider
 {
@@ -848,8 +859,8 @@ var auditProvider = new InMemoryAuditProvider();
 var foundry = WorkflowForge.CreateFoundry("OrderProcessing");
 foundry.UseAudit(
     auditProvider,
-    initiatedBy: "admin@company.com",
-    includeMetadata: true);
+    new AuditMiddlewareOptions { DetailLevel = AuditDetailLevel.Verbose },
+    initiatedBy: "admin@company.com");
 
 // Workflow operations are automatically audited
 var workflow = WorkflowForge.CreateWorkflow()
@@ -883,15 +894,15 @@ public class DatabaseAuditProvider : IAuditProvider
 {
     private readonly DbContext _context;
 
-    public async Task WriteAuditEntryAsync(AuditEntry entry)
+    public async Task WriteAuditEntryAsync(AuditEntry entry, CancellationToken cancellationToken = default)
     {
         _context.AuditLog.Add(entry);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task FlushAsync()
+    public async Task FlushAsync(CancellationToken cancellationToken = default)
     {
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }
 
@@ -902,17 +913,21 @@ foundry.UseAudit(auditProvider);
 
 **Audit Entry Structure:**
 ```csharp
-public class AuditEntry
+public sealed class AuditEntry
 {
-    public Guid AuditId { get; init; }
-    public DateTimeOffset Timestamp { get; init; }
-    public string WorkflowName { get; init; }
-    public string OperationName { get; init; }
-    public AuditEventType EventType { get; init; }
-    public string Status { get; init; }
-    public long? DurationMs { get; init; }
-    public string InitiatedBy { get; init; }
-    public IReadOnlyDictionary<string, string> Metadata { get; init; }
+    public Guid AuditId { get; }
+    public DateTimeOffset Timestamp { get; }
+    public Guid ExecutionId { get; }
+    public string WorkflowName { get; }
+    public string OperationName { get; }
+    public AuditEventType EventType { get; }
+    public string? InitiatedBy { get; }
+    public IReadOnlyDictionary<string, object?> Metadata { get; }
+    public string Status { get; }
+    public string? ErrorMessage { get; }
+    public long? DurationMs { get; }
+
+    // Populated via constructor (see the Audit extension source for the full signature).
 }
 ```
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -15,6 +15,7 @@ Install the package, model a short pipeline, run it with a smith and foundry.
 
 ## Table of Contents
 
+- [What's New in 2.1.2](#whats-new-in-212)
 - [What's New in 2.1.1](#whats-new-in-211)
 - [What's New in 2.0.0](#whats-new-in-200)
 - [Prerequisites](#prerequisites)
@@ -23,6 +24,12 @@ Install the package, model a short pipeline, run it with a smith and foundry.
 - [Core Concepts Explained](#core-concepts-explained)
 - [Next Steps](#next-steps)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## What's New in 2.1.2
+
+**2.1.2** is a bug-fix release: it fixes the Polly extension's missing `Microsoft.Bcl.TimeProvider` dependency (and the same class of issue in the OpenTelemetry/Serilog extensions), makes `EnablePerformanceMonitoring()` / `GetPerformanceStatistics()` work end-to-end, fixes a pooled-foundry state leak and audit workflow-name resolution, and centralizes package versioning. Full notes: [CHANGELOG.md](https://github.com/animatlabs/workflow-forge/blob/main/CHANGELOG.md).
 
 ---
 

--- a/docs/performance/performance.md
+++ b/docs/performance/performance.md
@@ -7,11 +7,11 @@ description: "Performance overview and benchmarks: comparative speedups and allo
 
 Where WorkflowForge sits on BenchmarkDotNet runs: internal numbers, comparisons, targets, and tuning notes.
 
-**Version**: 2.1.1  
+**Version**: 2.1.2  
 **Test System**: Windows 11 (25H2), Intel 11th Gen i7-1185G7, .NET SDK 10.0.103  
 **Runtimes**: .NET 10.0.3, .NET 8.0.24, .NET Framework 4.8.1  
 **BenchmarkDotNet**: v0.15.8, 50 iterations  
-**Last Updated**: March 2026
+**Last Updated**: July 2026
 
 ---
 

--- a/docs/performance/performance.md
+++ b/docs/performance/performance.md
@@ -236,7 +236,14 @@ BenchmarkDotNet writes output under `BenchmarkDotNet.Artifacts/results/`. Expect
 
 ## Version History
 
-### Version 2.1.1 (current, March 2026)
+### Version 2.1.2 (current, July 2026)
+
+- Fixed ILRepacked extensions (Polly/OpenTelemetry/Serilog) missing transitive dependencies
+- Implemented foundry performance monitoring (`EnablePerformanceMonitoring` / `GetPerformanceStatistics`)
+- Fixed pooled-foundry state leak and audit workflow-name resolution
+- Centralized package versioning and shared metadata
+
+### Version 2.1.1 (March 2026)
 
 - Multi-target .NET 10.0, .NET 8.0, .NET Framework 4.8
 - Sealed operation classes

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,15 @@
 <Project>
   <PropertyGroup>
+    <!-- Single source of truth for the version of every packable project (core + all extensions).
+         All packages release under this one number. PackageVersion is derived from Version by
+         MSBuild unless a project/CLI overrides it. Bump here when releasing. -->
+    <Version>2.1.2</Version>
+    <!-- Shared package metadata for every packable project (single source of truth). Per-project
+         values (e.g. Product, Description, PackageId) stay in each .csproj. -->
+    <Copyright>Copyright © 2025-2026 AnimatLabs</Copyright>
+    <PackageReleaseNotes>
+v2.1.2: Fixed ILRepacked extensions (Polly, OpenTelemetry, Serilog) that were missing transitive dependencies and threw a runtime FileNotFoundException (e.g. Microsoft.Bcl.TimeProvider) — the required BCL/Microsoft.Extensions packages now flow to consumers. Implemented foundry performance monitoring so EnablePerformanceMonitoring()/GetPerformanceStatistics() work end-to-end. Fixed pooled-foundry state leaking across executions and audit entries recording "Unknown" workflow names. Centralized package versioning and shared metadata. Hardened lifecycle-event exception isolation and smith disposal.
+    </PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>

--- a/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
+++ b/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
@@ -22,20 +22,20 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <!-- Workflow Core - Established workflow engine (latest stable) -->
-    <PackageReference Include="WorkflowCore" Version="3.17.0" />
+    <PackageReference Include="WorkflowCore" Version="3.18.0" />
     
     <!-- Microsoft Extensions - Match Elsa's requirements -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Elsa only on net8.0+ (it doesn't support net48) -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <PackageReference Include="Elsa" Version="3.5.3" />
-    <PackageReference Include="Elsa.Workflows.Core" Version="3.5.3" />
-    <PackageReference Include="Elsa.Workflows.Runtime" Version="3.5.3" />
+    <PackageReference Include="Elsa" Version="3.7.1" />
+    <PackageReference Include="Elsa.Workflows.Core" Version="3.7.1" />
+    <PackageReference Include="Elsa.Workflows.Runtime" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
+++ b/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
@@ -13,7 +13,6 @@
     <AssemblyName>WorkflowForge.Benchmarks.Comparative</AssemblyName>
     <RootNamespace>WorkflowForge.Benchmarks.Comparative</RootNamespace>
     <Description>Comparative performance benchmarks: WorkflowForge vs Workflow Core vs Elsa Workflows</Description>
-    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
+++ b/src/benchmarks/WorkflowForge.Benchmarks.Comparative/WorkflowForge.Benchmarks.Comparative.csproj
@@ -20,6 +20,7 @@
     <!-- BenchmarkDotNet for scientific performance measurement -->
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <!-- Workflow Core - Established workflow engine (latest stable) -->
     <PackageReference Include="WorkflowCore" Version="3.17.0" />
     

--- a/src/core/WorkflowForge.Testing/WorkflowForge.Testing.csproj
+++ b/src/core/WorkflowForge.Testing/WorkflowForge.Testing.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,7 +26,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -37,9 +35,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated to align with WorkflowForge v2.1.0 breaking changes. Removed SupportsRestore references from test helpers.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,7 +47,7 @@ v2.1.0: Updated to align with WorkflowForge v2.1.0 breaking changes. Removed Sup
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/core/WorkflowForge/WorkflowForge.csproj
+++ b/src/core/WorkflowForge/WorkflowForge.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,7 +26,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -37,9 +35,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: BREAKING: Removed SupportsRestore property from IWorkflowOperation and IWorkflow interfaces. Compensation now always attempts RestoreAsync (no-op default). Added optional restoreAction on WorkflowBuilder.AddOperation. Added FoundryPropertyKeys constants. Sealed EventArgs and Exception classes. Fixed event handler memory leaks, dispose race conditions, PersistenceMiddleware O(n²) indexing, and thread safety issues. Added CI/CD pipeline and cross-platform publish script.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -68,7 +63,7 @@ v2.1.0: BREAKING: Removed SupportsRestore property from IWorkflowOperation and I
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/core/WorkflowForge/WorkflowFoundry.cs
+++ b/src/core/WorkflowForge/WorkflowFoundry.cs
@@ -350,9 +350,18 @@ namespace WorkflowForge
             Properties[FoundryPropertyKeys.LastFailedId] = operation.Id;
 
             var operationDuration = _timeProvider.UtcNow - operationStartTime;
-            OperationFailed?.Invoke(this, new OperationFailedEventArgs(
-                operation, this, null, ex,
-                TimeSpan.FromMilliseconds(operationDuration.TotalMilliseconds)));
+            try
+            {
+                OperationFailed?.Invoke(this, new OperationFailedEventArgs(
+                    operation, this, null, ex,
+                    TimeSpan.FromMilliseconds(operationDuration.TotalMilliseconds)));
+            }
+            catch (Exception handlerEx)
+            {
+                // A throwing event subscriber must not replace or mask the operation's real
+                // exception (which is re-thrown below). Log and continue.
+                Logger.LogError(Logger.CreateErrorProperties(handlerEx, "OperationFailed"), handlerEx, "OperationFailed event handler error");
+            }
 
             if (ex is OperationCanceledException)
             {
@@ -475,8 +484,23 @@ namespace WorkflowForge
             _executionState = 0;
             _isFrozen = false;
 
-            // Dispose handles full cleanup of collections/properties,
-            // so this just needs to reset the flags.
+            // Clear all per-execution state. This foundry is being reused from a pool, and Dispose
+            // is NOT called on the pooled path — so unless we clear here, a previous workflow's
+            // Properties (including operation-tracking keys such as LastCompletedIndex and cached
+            // operation outputs) leak into the next, unrelated workflow. That both bleeds data
+            // across executions and can crash compensation with a stale index when a later, smaller
+            // workflow fails.
+            lock (_operations)
+            {
+                _operations.Clear();
+                _cachedOperations = null;
+            }
+            lock (_middlewareLock)
+            {
+                _middlewares.Clear();
+                _cachedMiddlewares = null;
+            }
+            Properties.Clear();
         }
     }
 }

--- a/src/core/WorkflowForge/WorkflowSmith.cs
+++ b/src/core/WorkflowForge/WorkflowSmith.cs
@@ -130,6 +130,13 @@ namespace WorkflowForge
                 {
                     ((WorkflowFoundry)foundry).Reset(Guid.NewGuid(), _logger, _serviceProvider, _options, null);
                     _foundryPool.Add(foundry);
+
+                    // Guard against a Dispose() that ran after the _disposed check above and already
+                    // drained the pool: re-drain so this just-added foundry cannot leak un-disposed.
+                    if (_disposed)
+                    {
+                        DrainFoundryPool();
+                    }
                 }
                 else
                 {
@@ -213,7 +220,7 @@ namespace WorkflowForge
                 _logger.LogInformation(WorkflowLogMessageConstants.WorkflowExecutionStarted);
 
                 // FIRE: WorkflowStarted event
-                WorkflowStarted?.Invoke(this, new WorkflowStartedEventArgs(foundry, _timeProvider.UtcNow));
+                RaiseEvent(() => WorkflowStarted?.Invoke(this, new WorkflowStartedEventArgs(foundry, _timeProvider.UtcNow)), "WorkflowStarted");
 
                 try
                 {
@@ -226,12 +233,15 @@ namespace WorkflowForge
 
                     // FIRE: WorkflowCompleted event
                     var duration = _timeProvider.UtcNow - startTime;
-                    var finalProperties = new Dictionary<string, object?>(foundry.Properties);
-                    WorkflowCompleted?.Invoke(this, new WorkflowCompletedEventArgs(
-                        foundry,
-                        _timeProvider.UtcNow,
-                        finalProperties,
-                        duration));
+                    RaiseEvent(() =>
+                    {
+                        var finalProperties = new Dictionary<string, object?>(foundry.Properties);
+                        WorkflowCompleted?.Invoke(this, new WorkflowCompletedEventArgs(
+                            foundry,
+                            _timeProvider.UtcNow,
+                            finalProperties,
+                            duration));
+                    }, "WorkflowCompleted");
                 }
                 catch (OperationCanceledException)
                 {
@@ -284,12 +294,12 @@ namespace WorkflowForge
             var failedOperationName = foundry.Properties.TryGetValue(FoundryPropertyKeys.LastFailedName, out var failedNameValue)
                 ? failedNameValue?.ToString() ?? FoundryPropertyKeys.UnknownValue
                 : FoundryPropertyKeys.UnknownValue;
-            WorkflowFailed?.Invoke(this, new WorkflowFailedEventArgs(
+            RaiseEvent(() => WorkflowFailed?.Invoke(this, new WorkflowFailedEventArgs(
                 foundry,
                 _timeProvider.UtcNow,
                 ex,
                 failedOperationName,
-                duration));
+                duration)), "WorkflowFailed");
 
             // Always attempt compensation — the base class no-op handles non-restorable operations
             var lastForgedIndex = -1;
@@ -398,12 +408,12 @@ namespace WorkflowForge
             _logger.LogInformation(WorkflowLogMessageConstants.CompensationProcessStarted);
 
             // FIRE: CompensationTriggered event
-            CompensationTriggered?.Invoke(this, new CompensationTriggeredEventArgs(
+            RaiseEvent(() => CompensationTriggered?.Invoke(this, new CompensationTriggeredEventArgs(
                 foundry,
                 _timeProvider.UtcNow,
                 "Operation failed, initiating compensation",
                 lastForgedIndex < operations.Count ? operations[lastForgedIndex].Name : FoundryPropertyKeys.UnknownValue,
-                null));
+                null)), "CompensationTriggered");
 
             int successCount = 0;
             int failureCount = 0;
@@ -430,7 +440,7 @@ namespace WorkflowForge
                     _logger.LogDebug(WorkflowLogMessageConstants.CompensationActionStarted);
 
                     // FIRE: OperationRestoreStarted event
-                    OperationRestoreStarted?.Invoke(this, new OperationRestoreStartedEventArgs(operation, foundry));
+                    RaiseEvent(() => OperationRestoreStarted?.Invoke(this, new OperationRestoreStartedEventArgs(operation, foundry)), "OperationRestoreStarted");
 
                     object? outputData = null;
                     var outputKey = string.Format(FoundryPropertyKeys.OperationOutputFormat, i, operation.Name);
@@ -446,10 +456,10 @@ namespace WorkflowForge
                     var restoreDuration = _timeProvider.UtcNow - restoreStartTime;
 
                     // FIRE: OperationRestoreCompleted event
-                    OperationRestoreCompleted?.Invoke(this, new OperationRestoreCompletedEventArgs(
+                    RaiseEvent(() => OperationRestoreCompleted?.Invoke(this, new OperationRestoreCompletedEventArgs(
                         operation,
                         foundry,
-                        restoreDuration));
+                        restoreDuration)), "OperationRestoreCompleted");
 
                     successCount++;
                 }
@@ -468,11 +478,11 @@ namespace WorkflowForge
                     var restoreDuration = _timeProvider.UtcNow - restoreStartTime;
 
                     // FIRE: OperationRestoreFailed event
-                    OperationRestoreFailed?.Invoke(this, new OperationRestoreFailedEventArgs(
+                    RaiseEvent(() => OperationRestoreFailed?.Invoke(this, new OperationRestoreFailedEventArgs(
                         operation,
                         foundry,
                         compensationEx,
-                        restoreDuration));
+                        restoreDuration)), "OperationRestoreFailed");
 
                     failureCount++;
                     errors.Add(compensationEx);
@@ -491,12 +501,12 @@ namespace WorkflowForge
             var totalCompensationDuration = _timeProvider.UtcNow - compensationStartTime;
 
             // FIRE: CompensationCompleted event
-            CompensationCompleted?.Invoke(this, new CompensationCompletedEventArgs(
+            RaiseEvent(() => CompensationCompleted?.Invoke(this, new CompensationCompletedEventArgs(
                 foundry,
                 _timeProvider.UtcNow,
                 successCount,
                 failureCount,
-                TimeSpan.FromMilliseconds(totalCompensationDuration.TotalMilliseconds)));
+                TimeSpan.FromMilliseconds(totalCompensationDuration.TotalMilliseconds))), "CompensationCompleted");
 
             return errors;
         }
@@ -551,6 +561,23 @@ namespace WorkflowForge
         }
 
         /// <summary>
+        /// Raises a lifecycle event, isolating subscriber exceptions. A throwing handler must not
+        /// replace the workflow's real outcome, nor abort the compensation loop partway through.
+        /// Handler failures are logged and swallowed.
+        /// </summary>
+        private void RaiseEvent(Action raise, string eventName)
+        {
+            try
+            {
+                raise();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(_logger.CreateErrorProperties(ex, eventName), ex, eventName + " event handler error");
+            }
+        }
+
+        /// <summary>
         /// Releases all resources used by the WorkflowSmith.
         /// </summary>
         public void Dispose()
@@ -562,12 +589,7 @@ namespace WorkflowForge
 
             _concurrencyLimiter?.Dispose();
 
-            while (_foundryPool.TryTake(out var pooledFoundry))
-            {
-                try
-                { pooledFoundry.Dispose(); }
-                catch (Exception ex) { _logger.LogWarning(ex, "Pooled foundry disposal failed"); }
-            }
+            DrainFoundryPool();
 
             WorkflowStarted = null;
             WorkflowCompleted = null;
@@ -578,10 +600,26 @@ namespace WorkflowForge
             OperationRestoreCompleted = null;
             OperationRestoreFailed = null;
 
-            foreach (var middleware in _workflowMiddlewares)
-                (middleware as IDisposable)?.Dispose();
+            // Take the same lock every other access to _workflowMiddlewares uses, to avoid a
+            // torn read / "collection modified" if AddWorkflowMiddleware runs concurrently.
+            lock (_workflowMiddlewareLock)
+            {
+                foreach (var middleware in _workflowMiddlewares)
+                    (middleware as IDisposable)?.Dispose();
+            }
 
             GC.SuppressFinalize(this);
+        }
+
+        private void DrainFoundryPool()
+        {
+            while (_foundryPool.TryTake(out var pooledFoundry))
+            {
+                Interlocked.Decrement(ref _poolCount);
+                try
+                { pooledFoundry.Dispose(); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Pooled foundry disposal failed"); }
+            }
         }
 
         private void ThrowIfDisposed()

--- a/src/extensions/WorkflowForge.Extensions.Audit/AuditExtensions.cs
+++ b/src/extensions/WorkflowForge.Extensions.Audit/AuditExtensions.cs
@@ -86,9 +86,13 @@ namespace WorkflowForge.Extensions.Audit
                 throw new ArgumentException("Operation name cannot be null or empty", nameof(operationName));
 
             var time = timeProvider ?? SystemTimeProvider.Instance;
-            var workflowName = foundry.Properties.TryGetValue(FoundryPropertyKeys.WorkflowName, out var wfName)
-                ? wfName?.ToString() ?? FoundryPropertyKeys.UnknownValue
-                : FoundryPropertyKeys.UnknownValue;
+            // Prefer the live workflow name from the foundry (the framework never writes the
+            // WorkflowName property key). Fall back to the property (if a caller set it) then Unknown.
+            var workflowName = foundry.CurrentWorkflow?.Name
+                ?? (foundry.Properties.TryGetValue(FoundryPropertyKeys.WorkflowName, out var wfName)
+                    ? wfName?.ToString()
+                    : null)
+                ?? FoundryPropertyKeys.UnknownValue;
 
             var entry = new AuditEntry(
                 foundry.ExecutionId,

--- a/src/extensions/WorkflowForge.Extensions.Audit/AuditMiddleware.cs
+++ b/src/extensions/WorkflowForge.Extensions.Audit/AuditMiddleware.cs
@@ -51,9 +51,13 @@ namespace WorkflowForge.Extensions.Audit
             var startTime = _timeProvider.UtcNow;
             var stopwatch = Stopwatch.StartNew();
 
-            var workflowName = foundry.Properties.TryGetValue(FoundryPropertyKeys.WorkflowName, out var wfName)
-                ? wfName?.ToString() ?? FoundryPropertyKeys.UnknownValue
-                : FoundryPropertyKeys.UnknownValue;
+            // Prefer the live workflow name from the foundry (the framework never writes the
+            // WorkflowName property key). Fall back to the property (if a caller set it) then Unknown.
+            var workflowName = foundry.CurrentWorkflow?.Name
+                ?? (foundry.Properties.TryGetValue(FoundryPropertyKeys.WorkflowName, out var wfName)
+                    ? wfName?.ToString()
+                    : null)
+                ?? FoundryPropertyKeys.UnknownValue;
 
             // Log operation started
             await WriteAuditEntryAsync(

--- a/src/extensions/WorkflowForge.Extensions.Audit/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Audit/README.md
@@ -43,7 +43,7 @@ await smith.ForgeAsync(workflow, foundry);
 
 ## Key points
 
-- Only pulls in WorkflowForge core; you supply storage by implementing `IAuditProvider`.
+- Depends on WorkflowForge core plus `Microsoft.Extensions.*` (options/DI integration); no storage library — you supply storage by implementing `IAuditProvider`.
 - Covers workflow and operation lifecycle events in one stream.
 - Optional initiator/session-style context and timestamps; detail level is configurable.
 - `ISystemTimeProvider` helps keep tests deterministic.

--- a/src/extensions/WorkflowForge.Extensions.Audit/WorkflowForge.Extensions.Audit.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Audit/WorkflowForge.Extensions.Audit.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -28,7 +27,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -38,9 +36,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,7 +48,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Audit/WorkflowForge.Extensions.Audit.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Audit/WorkflowForge.Extensions.Audit.csproj
@@ -43,11 +43,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.DependencyInjection/WorkflowForge.Extensions.DependencyInjection.csproj
+++ b/src/extensions/WorkflowForge.Extensions.DependencyInjection/WorkflowForge.Extensions.DependencyInjection.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -27,7 +26,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -37,9 +35,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,7 +53,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.DependencyInjection/WorkflowForge.Extensions.DependencyInjection.csproj
+++ b/src/extensions/WorkflowForge.Extensions.DependencyInjection/WorkflowForge.Extensions.DependencyInjection.csproj
@@ -47,12 +47,12 @@
     <ProjectReference Include="../../core/WorkflowForge/WorkflowForge.csproj" />
     
     <!-- Microsoft.Extensions.* packages for DI and IOptions -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Logging.Serilog/ILRepack.targets
+++ b/src/extensions/WorkflowForge.Extensions.Logging.Serilog/ILRepack.targets
@@ -25,4 +25,11 @@
     <Delete Files="$(OutputPath)Serilog.Extensions.Logging.dll" Condition="Exists('$(OutputPath)Serilog.Extensions.Logging.dll')" />
     <Delete Files="$(OutputPath)Serilog.Sinks.Console.dll" Condition="Exists('$(OutputPath)Serilog.Sinks.Console.dll')" />
   </Target>
+
+  <!-- Guard: ILRepack only runs in Release. Packing in any other configuration would produce a
+       package whose merged Serilog assemblies were never merged in, causing runtime load failures.
+       Fail fast so a stray `dotnet pack` (Debug by default) cannot ship a broken package. -->
+  <Target Name="WorkflowForgeGuardReleasePack" BeforeTargets="Pack" Condition="!$(Configuration.Contains('Release'))">
+    <Error Text="WorkflowForge.Extensions.Logging.Serilog uses ILRepack, which only runs in Release. Pack with 'dotnet pack -c Release' to produce a valid package." />
+  </Target>
 </Project>

--- a/src/extensions/WorkflowForge.Extensions.Logging.Serilog/WorkflowForge.Extensions.Logging.Serilog.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Logging.Serilog/WorkflowForge.Extensions.Logging.Serilog.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -26,7 +25,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -38,9 +36,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,8 +48,18 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Serilog" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" PrivateAssets="all" />
+    <!--
+      Serilog* assemblies are ILRepack-merged (PrivateAssets="all"), so their transitive
+      dependencies are NOT written to this package's nuspec. The merged IL still references these
+      at runtime; declare them as regular (flowing) dependencies so consumers don't hit
+      FileNotFoundException. Microsoft.Extensions.Logging (full) is distinct from the .Abstractions
+      reference above and pulls its own subtree. Do NOT ILRepack these (System.* identity).
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Logging.Serilog/WorkflowForge.Extensions.Logging.Serilog.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Logging.Serilog/WorkflowForge.Extensions.Logging.Serilog.csproj
@@ -44,8 +44,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Serilog" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" PrivateAssets="all" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" PrivateAssets="all" />
     <!--
@@ -55,10 +55,10 @@
       FileNotFoundException. Microsoft.Extensions.Logging (full) is distinct from the .Abstractions
       reference above and pulls its own subtree. Do NOT ILRepack these (System.* identity).
     -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.10" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.46" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Observability.HealthChecks/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Observability.HealthChecks/README.md
@@ -97,13 +97,13 @@ if (result?.Status == HealthStatus.Unhealthy)
 }
 ```
 
-[Health checks configuration](../../../docs/core/configuration.md#health-checks-extension)
+[Health checks configuration](../../../docs/core/configuration.md)
 
 You can surface results over ASP.NET Core `/health`, Application Insights, Prometheus, or your own dashboards.
 
 ## Links
 
 - [Getting Started](../../../docs/getting-started/getting-started.md)
-- [Configuration Guide](../../../docs/core/configuration.md#health-checks-extension)
+- [Configuration Guide](../../../docs/core/configuration.md)
 - [Extensions Overview](../../../docs/extensions/index.md)
 - [Sample 16: Health Checks](../../samples/WorkflowForge.Samples.BasicConsole/README.md)

--- a/src/extensions/WorkflowForge.Extensions.Observability.HealthChecks/WorkflowForge.Extensions.Observability.HealthChecks.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Observability.HealthChecks/WorkflowForge.Extensions.Observability.HealthChecks.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -28,7 +27,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -38,9 +36,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,7 +48,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/ILRepack.targets
+++ b/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/ILRepack.targets
@@ -25,4 +25,11 @@
     <Delete Files="$(OutputPath)OpenTelemetry.Api.dll" Condition="Exists('$(OutputPath)OpenTelemetry.Api.dll')" />
     <Delete Files="$(OutputPath)OpenTelemetry.Api.ProviderBuilderExtensions.dll" Condition="Exists('$(OutputPath)OpenTelemetry.Api.ProviderBuilderExtensions.dll')" />
   </Target>
+
+  <!-- Guard: ILRepack only runs in Release. Packing in any other configuration would produce a
+       package whose merged OpenTelemetry assemblies were never merged in, causing runtime load
+       failures. Fail fast so a stray `dotnet pack` (Debug by default) cannot ship a broken package. -->
+  <Target Name="WorkflowForgeGuardReleasePack" BeforeTargets="Pack" Condition="!$(Configuration.Contains('Release'))">
+    <Error Text="WorkflowForge.Extensions.Observability.OpenTelemetry uses ILRepack, which only runs in Release. Pack with 'dotnet pack -c Release' to produce a valid package." />
+  </Target>
 </Project>

--- a/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowForge.Extensions.Observability.OpenTelemetry.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowForge.Extensions.Observability.OpenTelemetry.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -28,7 +27,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -40,9 +38,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,8 +47,18 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry" Version="1.15.3" PrivateAssets="all" />
+    <!--
+      OpenTelemetry* assemblies are ILRepack-merged (PrivateAssets="all"), so their transitive
+      dependencies are NOT written to this package's nuspec. The merged IL still references these
+      at runtime; declare them as regular (flowing) dependencies so consumers don't hit
+      FileNotFoundException. Do NOT ILRepack these (System.*/Microsoft.Extensions.* identity).
+    -->
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowForge.Extensions.Observability.OpenTelemetry.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowForge.Extensions.Observability.OpenTelemetry.csproj
@@ -45,19 +45,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" PrivateAssets="all" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.3" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.17.0" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" PrivateAssets="all" />
     <!--
       OpenTelemetry* assemblies are ILRepack-merged (PrivateAssets="all"), so their transitive
       dependencies are NOT written to this package's nuspec. The merged IL still references these
       at runtime; declare them as regular (flowing) dependencies so consumers don't hit
       FileNotFoundException. Do NOT ILRepack these (System.*/Microsoft.Extensions.* identity).
     -->
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.46" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowFoundryTelemetryExtensions.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.OpenTelemetry/WorkflowFoundryTelemetryExtensions.cs
@@ -118,8 +118,8 @@ namespace WorkflowForge.Extensions.Observability.OpenTelemetry
                 if (foundry.Properties.TryGetValue(OpenTelemetryServiceKey, out var serviceObj) && serviceObj is WorkflowForgeOpenTelemetryService service)
                 {
                     service.Dispose();
-                    // Remove from foundry properties
-                    foundry.Properties[OpenTelemetryServiceKey] = null;
+                    // Remove the key entirely (rather than leaving a null value behind).
+                    foundry.Properties.TryRemove(OpenTelemetryServiceKey, out _);
                     foundry.Logger.LogInformation("OpenTelemetry disabled for foundry");
                     return true;
                 }

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/Constants/PerformancePropertyKeys.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/Constants/PerformancePropertyKeys.cs
@@ -7,5 +7,11 @@ namespace WorkflowForge.Extensions.Observability.Performance.Constants
     {
         /// <summary>Property key for storing performance statistics on the foundry.</summary>
         internal const string PerformanceStatistics = "PerformanceStatistics";
+
+        /// <summary>
+        /// Property key for storing the performance middleware instance on the foundry, so that
+        /// <c>DisablePerformanceMonitoring</c> can remove it again.
+        /// </summary>
+        internal const string PerformanceMiddleware = "PerformanceMiddleware";
     }
 }

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/Constants/PerformancePropertyKeys.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/Constants/PerformancePropertyKeys.cs
@@ -9,8 +9,8 @@ namespace WorkflowForge.Extensions.Observability.Performance.Constants
         internal const string PerformanceStatistics = "PerformanceStatistics";
 
         /// <summary>
-        /// Property key for storing the performance middleware instance on the foundry, so that
-        /// <c>DisablePerformanceMonitoring</c> can remove it again.
+        /// Property key marking that the performance middleware has already been registered on the
+        /// foundry, so repeated <c>EnablePerformanceMonitoring</c> calls do not register it twice.
         /// </summary>
         internal const string PerformanceMiddleware = "PerformanceMiddleware";
     }

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/PerformanceStatisticsMiddleware.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/PerformanceStatisticsMiddleware.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using WorkflowForge.Abstractions;
+using WorkflowForge.Extensions.Observability.Performance.Constants;
+
+namespace WorkflowForge.Extensions.Observability.Performance
+{
+    /// <summary>
+    /// Operation middleware that records timing, success/failure, and approximate memory allocation
+    /// for each operation into a <see cref="FoundryPerformanceStatistics"/> instance.
+    /// <para>
+    /// Added automatically by <see cref="WorkflowFoundryPerformanceExtensions.EnablePerformanceMonitoring"/>.
+    /// In that mode the middleware resolves the active statistics from the foundry properties on each
+    /// call, so enabling/disabling monitoring is a matter of setting/removing that property — the
+    /// middleware simply no-ops while no statistics object is present.
+    /// </para>
+    /// <para>
+    /// For standalone use, construct it with an explicit <see cref="FoundryPerformanceStatistics"/>
+    /// and add it via <c>foundry.AddMiddleware(...)</c>; it will always record into that instance.
+    /// </para>
+    /// </summary>
+    public sealed class PerformanceStatisticsMiddleware : IWorkflowOperationMiddleware
+    {
+        private readonly FoundryPerformanceStatistics? _explicitStatistics;
+
+        /// <summary>
+        /// Initializes a middleware that resolves the active statistics from the foundry properties
+        /// on each call (the mode used by <c>EnablePerformanceMonitoring</c>).
+        /// </summary>
+        public PerformanceStatisticsMiddleware()
+        {
+            _explicitStatistics = null;
+        }
+
+        /// <summary>
+        /// Initializes a middleware that always records into the supplied statistics instance.
+        /// </summary>
+        /// <param name="statistics">The statistics accumulator to record into.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="statistics"/> is null.</exception>
+        public PerformanceStatisticsMiddleware(FoundryPerformanceStatistics statistics)
+        {
+            _explicitStatistics = statistics ?? throw new ArgumentNullException(nameof(statistics));
+        }
+
+        /// <inheritdoc />
+        public async Task<object?> ExecuteAsync(
+            IWorkflowOperation operation,
+            IWorkflowFoundry foundry,
+            object? inputData,
+            Func<CancellationToken, Task<object?>> next,
+            CancellationToken cancellationToken = default)
+        {
+            if (operation == null) throw new ArgumentNullException(nameof(operation));
+            if (foundry == null) throw new ArgumentNullException(nameof(foundry));
+            if (next == null) throw new ArgumentNullException(nameof(next));
+
+            var statistics = _explicitStatistics ?? ResolveStatistics(foundry);
+            if (statistics == null)
+            {
+                // Monitoring not active on this foundry: pass through with no overhead.
+                return await next(cancellationToken).ConfigureAwait(false);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            // GC.GetTotalMemory is a coarse, process-wide approximation (the only allocation API
+            // available on netstandard2.0); treated as best-effort and clamped to non-negative.
+            var memoryBefore = GC.GetTotalMemory(false);
+            var success = false;
+
+            try
+            {
+                var result = await next(cancellationToken).ConfigureAwait(false);
+                success = true;
+                return result;
+            }
+            finally
+            {
+                stopwatch.Stop();
+                var memoryDelta = GC.GetTotalMemory(false) - memoryBefore;
+                statistics.Record(operation.Name, operation.Id.ToString(), stopwatch.Elapsed, success, memoryDelta);
+            }
+        }
+
+        private static FoundryPerformanceStatistics? ResolveStatistics(IWorkflowFoundry foundry)
+        {
+            return foundry.Properties.TryGetValue(PerformancePropertyKeys.PerformanceStatistics, out var statsObj)
+                && statsObj is FoundryPerformanceStatistics statistics
+                ? statistics
+                : null;
+        }
+    }
+}

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/README.md
@@ -10,30 +10,38 @@ Measure per-operation timing and memory from middleware, and read aggregate stat
 dotnet add package WorkflowForge.Extensions.Observability.Performance
 ```
 
-Targets .NET Standard 2.0 or later. Beyond WorkflowForge core, the package adds no extra NuGet dependencies.
+Targets .NET Standard 2.0. Beyond WorkflowForge core, it depends on `System.Diagnostics.DiagnosticSource` and `System.ComponentModel.Annotations` (both provided by the runtime on modern .NET).
 
 ## Quick Start
 
-Add timing middleware on the foundry for performance monitoring:
+Call `EnablePerformanceMonitoring()` before running the workflow, then read the aggregated
+statistics afterward with `GetPerformanceStatistics()`:
 
 ```csharp
 using WorkflowForge;
 using WorkflowForge.Extensions.Observability.Performance;
 
 using var foundry = WorkflowForge.CreateFoundry("PerformanceMonitored");
+foundry.EnablePerformanceMonitoring();
 
-// Add timing middleware to track operation performance (see Custom Timing Middleware section below)
-foundry.AddMiddleware(new DetailedTimingMiddleware(foundry.Logger, TimeSpan.FromMilliseconds(100)));
-
-var smith = WorkflowForge.CreateSmith();
+using var smith = WorkflowForge.CreateSmith();
 var workflow = WorkflowForge.CreateWorkflow("PerformanceMonitored")
     .AddOperation(new ActionWorkflowOperation("Step1", async (input, foundry, ct) => { /* ... */ }))
     .Build();
 
+// Pass the SAME foundry you enabled monitoring on so the stats survive the run.
 await smith.ForgeAsync(workflow, foundry);
+
+var stats = foundry.GetPerformanceStatistics();
+Console.WriteLine($"Operations: {stats!.TotalOperations}, success rate: {stats.SuccessRate:P0}");
+foreach (var op in stats.GetAllOperationStatistics())
+    Console.WriteLine($"{op.OperationName}: avg {op.AverageExecutionTime.TotalMilliseconds:F2} ms");
 ```
 
-> **Note:** The `EnablePerformanceMonitoring()` and `GetPerformanceStatistics()` extension methods require a foundry that implements `IPerformanceMonitoredFoundry`. Standard foundries created via `WorkflowForge.CreateFoundry()` use the middleware pattern shown above instead.
+`EnablePerformanceMonitoring()` registers a `PerformanceStatisticsMiddleware` and stores a
+`FoundryPerformanceStatistics` on the foundry; the middleware records timing, success/failure, and
+approximate memory per operation. For custom needs you can add your own middleware instead (see
+[Custom Timing Middleware](#custom-timing-middleware)).
 
 ## Key points
 
@@ -53,7 +61,7 @@ foundry.AddMiddleware(new DetailedTimingMiddleware(foundry.Logger, TimeSpan.From
 
 - `IFoundryPerformanceStatistics` and `IOperationStatistics` define the contract for built-in performance statistics on a foundry.
 
-[Performance extension](../../../docs/core/configuration.md#performance-extension)
+[Performance extension](../../../docs/core/configuration.md)
 
 ## Advanced usage
 
@@ -171,6 +179,6 @@ foreach (var opStats in stats.GetAllOperationStatistics())
 ## Links
 
 - [Getting Started](../../../docs/getting-started/getting-started.md)
-- [Configuration Guide](../../../docs/core/configuration.md#performance-extension)
+- [Configuration Guide](../../../docs/core/configuration.md)
 - [Extensions Overview](../../../docs/extensions/index.md)
 - [Sample 17: Performance Monitoring](../../samples/WorkflowForge.Samples.BasicConsole/)

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/Statistics/FoundryPerformanceStatistics.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/Statistics/FoundryPerformanceStatistics.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using WorkflowForge.Abstractions;
+using WorkflowForge.Extensions.Observability.Performance.Abstractions;
+
+namespace WorkflowForge.Extensions.Observability.Performance
+{
+    /// <summary>
+    /// Thread-safe aggregate of foundry performance statistics, collected across all operations
+    /// executed while performance monitoring is enabled. Populated by
+    /// <see cref="PerformanceStatisticsMiddleware"/> and retrieved via
+    /// <see cref="WorkflowFoundryPerformanceExtensions.GetPerformanceStatistics"/>.
+    /// </summary>
+    public sealed class FoundryPerformanceStatistics : IFoundryPerformanceStatistics
+    {
+        private readonly object _lock = new object();
+        private readonly ISystemTimeProvider _timeProvider;
+        private readonly Dictionary<string, OperationStatistics> _operations =
+            new Dictionary<string, OperationStatistics>(StringComparer.Ordinal);
+
+        private int _totalOperations;
+        private int _successfulOperations;
+        private int _failedOperations;
+        private long _totalTicks;
+        private long _minTicks = long.MaxValue;
+        private long _maxTicks;
+        private long _totalMemory;
+        private readonly DateTimeOffset _startTime;
+        private DateTimeOffset _endTime;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FoundryPerformanceStatistics"/> class.
+        /// </summary>
+        /// <param name="timeProvider">Optional time provider (defaults to the system clock).</param>
+        public FoundryPerformanceStatistics(ISystemTimeProvider? timeProvider = null)
+        {
+            _timeProvider = timeProvider ?? SystemTimeProvider.Instance;
+            _startTime = _timeProvider.UtcNow;
+            _endTime = _startTime;
+        }
+
+        /// <summary>
+        /// Records a single operation execution into the aggregate and per-operation statistics.
+        /// </summary>
+        /// <param name="operationName">The operation name.</param>
+        /// <param name="operationId">The operation identifier.</param>
+        /// <param name="duration">Execution duration.</param>
+        /// <param name="success">Whether the execution succeeded.</param>
+        /// <param name="memoryAllocated">Approximate bytes allocated during the execution.</param>
+        public void Record(string operationName, string operationId, TimeSpan duration, bool success, long memoryAllocated)
+        {
+            if (operationName == null) throw new ArgumentNullException(nameof(operationName));
+            if (operationId == null) throw new ArgumentNullException(nameof(operationId));
+
+            var ticks = duration.Ticks;
+            if (ticks < 0) ticks = 0;
+            if (memoryAllocated < 0) memoryAllocated = 0;
+
+            lock (_lock)
+            {
+                _totalOperations++;
+                if (success) _successfulOperations++; else _failedOperations++;
+                _totalTicks += ticks;
+                if (ticks < _minTicks) _minTicks = ticks;
+                if (ticks > _maxTicks) _maxTicks = ticks;
+                _totalMemory += memoryAllocated;
+                _endTime = _timeProvider.UtcNow;
+
+                if (!_operations.TryGetValue(operationName, out var opStats))
+                {
+                    opStats = new OperationStatistics(operationName, operationId);
+                    _operations[operationName] = opStats;
+                }
+
+                opStats.Record(ticks, success, memoryAllocated);
+            }
+        }
+
+        /// <inheritdoc />
+        public int TotalOperations { get { lock (_lock) { return _totalOperations; } } }
+
+        /// <inheritdoc />
+        public int SuccessfulOperations { get { lock (_lock) { return _successfulOperations; } } }
+
+        /// <inheritdoc />
+        public int FailedOperations { get { lock (_lock) { return _failedOperations; } } }
+
+        /// <inheritdoc />
+        public double SuccessRate
+        {
+            get { lock (_lock) { return _totalOperations == 0 ? 0.0 : (double)_successfulOperations / _totalOperations; } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan AverageDuration
+        {
+            get { lock (_lock) { return _totalOperations == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(_totalTicks / _totalOperations); } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan MinimumDuration
+        {
+            get { lock (_lock) { return _totalOperations == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(_minTicks); } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan MaximumDuration
+        {
+            get { lock (_lock) { return TimeSpan.FromTicks(_maxTicks); } }
+        }
+
+        /// <inheritdoc />
+        public long TotalMemoryAllocated { get { lock (_lock) { return _totalMemory; } } }
+
+        /// <inheritdoc />
+        public long AverageMemoryPerOperation
+        {
+            get { lock (_lock) { return _totalOperations == 0 ? 0 : _totalMemory / _totalOperations; } }
+        }
+
+        /// <inheritdoc />
+        public DateTimeOffset StartTime => _startTime;
+
+        /// <inheritdoc />
+        public DateTimeOffset EndTime { get { lock (_lock) { return _endTime; } } }
+
+        /// <inheritdoc />
+        public TimeSpan TotalDuration { get { lock (_lock) { return _endTime - _startTime; } } }
+
+        /// <inheritdoc />
+        public double OperationsPerSecond
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    var seconds = (_endTime - _startTime).TotalSeconds;
+                    return seconds <= 0 ? 0.0 : _totalOperations / seconds;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public IOperationStatistics? GetOperationStatistics(string operationName)
+        {
+            if (operationName == null) throw new ArgumentNullException(nameof(operationName));
+            lock (_lock)
+            {
+                return _operations.TryGetValue(operationName, out var stats) ? stats : null;
+            }
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<IOperationStatistics> GetAllOperationStatistics()
+        {
+            lock (_lock)
+            {
+                return new List<IOperationStatistics>(_operations.Values);
+            }
+        }
+    }
+}

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/Statistics/OperationStatistics.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/Statistics/OperationStatistics.cs
@@ -1,0 +1,103 @@
+using System;
+using WorkflowForge.Extensions.Observability.Performance.Abstractions;
+
+namespace WorkflowForge.Extensions.Observability.Performance
+{
+    /// <summary>
+    /// Thread-safe accumulator of performance statistics for a single named operation.
+    /// Populated by <see cref="PerformanceStatisticsMiddleware"/>.
+    /// </summary>
+    public sealed class OperationStatistics : IOperationStatistics
+    {
+        private readonly object _lock = new object();
+
+        private int _executionCount;
+        private int _successfulExecutions;
+        private int _failedExecutions;
+        private long _totalTicks;
+        private long _minTicks = long.MaxValue;
+        private long _maxTicks;
+        private long _totalMemory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationStatistics"/> class.
+        /// </summary>
+        /// <param name="operationName">The operation name.</param>
+        /// <param name="operationId">The operation identifier.</param>
+        public OperationStatistics(string operationName, string operationId)
+        {
+            OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
+            OperationId = operationId ?? throw new ArgumentNullException(nameof(operationId));
+        }
+
+        /// <inheritdoc />
+        public string OperationName { get; }
+
+        /// <inheritdoc />
+        public string OperationId { get; }
+
+        /// <summary>
+        /// Records a single execution of this operation.
+        /// </summary>
+        /// <param name="durationTicks">Execution duration in ticks (clamped to non-negative).</param>
+        /// <param name="success">Whether the execution succeeded.</param>
+        /// <param name="memoryAllocated">Approximate bytes allocated during the execution.</param>
+        internal void Record(long durationTicks, bool success, long memoryAllocated)
+        {
+            if (durationTicks < 0) durationTicks = 0;
+            if (memoryAllocated < 0) memoryAllocated = 0;
+
+            lock (_lock)
+            {
+                _executionCount++;
+                if (success) _successfulExecutions++; else _failedExecutions++;
+                _totalTicks += durationTicks;
+                if (durationTicks < _minTicks) _minTicks = durationTicks;
+                if (durationTicks > _maxTicks) _maxTicks = durationTicks;
+                _totalMemory += memoryAllocated;
+            }
+        }
+
+        /// <inheritdoc />
+        public int ExecutionCount { get { lock (_lock) { return _executionCount; } } }
+
+        /// <inheritdoc />
+        public int SuccessfulExecutions { get { lock (_lock) { return _successfulExecutions; } } }
+
+        /// <inheritdoc />
+        public int FailedExecutions { get { lock (_lock) { return _failedExecutions; } } }
+
+        /// <inheritdoc />
+        public double SuccessRate
+        {
+            get { lock (_lock) { return _executionCount == 0 ? 0.0 : (double)_successfulExecutions / _executionCount; } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan AverageExecutionTime
+        {
+            get { lock (_lock) { return _executionCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(_totalTicks / _executionCount); } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan MinimumExecutionTime
+        {
+            get { lock (_lock) { return _executionCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(_minTicks); } }
+        }
+
+        /// <inheritdoc />
+        public TimeSpan MaximumExecutionTime
+        {
+            get { lock (_lock) { return TimeSpan.FromTicks(_maxTicks); } }
+        }
+
+        /// <inheritdoc />
+        public long TotalMemoryAllocated { get { lock (_lock) { return _totalMemory; } } }
+
+        /// <inheritdoc />
+        public long AverageMemoryPerExecution
+        {
+            get { lock (_lock) { return _executionCount == 0 ? 0 : _totalMemory / _executionCount; } }
+        }
+    }
+}

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowForge.Extensions.Observability.Performance.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowForge.Extensions.Observability.Performance.csproj
@@ -47,7 +47,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowForge.Extensions.Observability.Performance.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowForge.Extensions.Observability.Performance.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -28,7 +27,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -38,9 +36,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,7 +43,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowFoundryPerformanceExtensions.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowFoundryPerformanceExtensions.cs
@@ -21,6 +21,12 @@ namespace WorkflowForge.Extensions.Observability.Performance
             if (foundry == null)
                 throw new ArgumentNullException(nameof(foundry));
 
+            // A foundry with native support wins; otherwise read the stats recorded by the middleware.
+            if (foundry is IPerformanceMonitoredFoundry performanceFoundry)
+            {
+                return performanceFoundry.GetPerformanceStatistics();
+            }
+
             return foundry.Properties.TryGetValue(PerformancePropertyKeys.PerformanceStatistics, out var statsObj) && statsObj is IFoundryPerformanceStatistics stats
                 ? stats
                 : null;
@@ -38,12 +44,25 @@ namespace WorkflowForge.Extensions.Observability.Performance
             if (foundry == null)
                 throw new ArgumentNullException(nameof(foundry));
 
+            // A foundry with native support handles it directly.
             if (foundry is IPerformanceMonitoredFoundry performanceFoundry)
             {
                 return performanceFoundry.EnablePerformanceMonitoring();
             }
 
-            return false;
+            // Standard foundry: store a fresh statistics accumulator under the well-known key. The
+            // PerformanceStatisticsMiddleware resolves that key on each operation and records into it.
+            foundry.Properties[PerformancePropertyKeys.PerformanceStatistics] = new FoundryPerformanceStatistics();
+
+            // Register the middleware exactly once per foundry (re-enabling only replaces the stats).
+            if (!foundry.Properties.ContainsKey(PerformancePropertyKeys.PerformanceMiddleware))
+            {
+                var middleware = new PerformanceStatisticsMiddleware();
+                foundry.Properties[PerformancePropertyKeys.PerformanceMiddleware] = middleware;
+                foundry.AddMiddleware(middleware);
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -63,7 +82,10 @@ namespace WorkflowForge.Extensions.Observability.Performance
                 return performanceFoundry.DisablePerformanceMonitoring();
             }
 
-            return false;
+            // Removing the statistics deactivates recording. The middleware stays registered but
+            // becomes a no-op pass-through until monitoring is enabled again. Returns whether
+            // monitoring was active.
+            return foundry.Properties.TryRemove(PerformancePropertyKeys.PerformanceStatistics, out _);
         }
     }
 

--- a/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowFoundryPerformanceExtensions.cs
+++ b/src/extensions/WorkflowForge.Extensions.Observability.Performance/WorkflowFoundryPerformanceExtensions.cs
@@ -54,11 +54,12 @@ namespace WorkflowForge.Extensions.Observability.Performance
             // PerformanceStatisticsMiddleware resolves that key on each operation and records into it.
             foundry.Properties[PerformancePropertyKeys.PerformanceStatistics] = new FoundryPerformanceStatistics();
 
-            // Register the middleware exactly once per foundry (re-enabling only replaces the stats).
-            if (!foundry.Properties.ContainsKey(PerformancePropertyKeys.PerformanceMiddleware))
+            // Register the middleware exactly once per foundry, even under concurrent EnablePerformanceMonitoring
+            // calls. TryAdd is atomic; a ContainsKey-then-add check would be a race that could register the
+            // middleware twice and permanently double-count every operation.
+            var middleware = new PerformanceStatisticsMiddleware();
+            if (foundry.Properties.TryAdd(PerformancePropertyKeys.PerformanceMiddleware, middleware))
             {
-                var middleware = new PerformanceStatisticsMiddleware();
-                foundry.Properties[PerformancePropertyKeys.PerformanceMiddleware] = middleware;
                 foundry.AddMiddleware(middleware);
             }
 

--- a/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/README.md
@@ -102,7 +102,7 @@ services.AddRecoveryConfiguration(configuration);
 var options = serviceProvider.GetRequiredService<IOptions<RecoveryMiddlewareOptions>>().Value;
 ```
 
-[Recovery configuration](../../../docs/core/configuration.md#recovery-extension)
+[Recovery configuration](../../../docs/core/configuration.md)
 
 ## Usage patterns
 
@@ -217,7 +217,7 @@ catch (Exception ex)
 ## Links
 
 - [Getting Started](../../../docs/getting-started/getting-started.md)
-- [Configuration Guide](../../../docs/core/configuration.md#recovery-extension)
+- [Configuration Guide](../../../docs/core/configuration.md)
 - [Extensions Overview](../../../docs/extensions/index.md)
 - [Persistence Extension](../WorkflowForge.Extensions.Persistence/README.md)
 - [Sample 21: Recovery](../../samples/WorkflowForge.Samples.BasicConsole/README.md)

--- a/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/RecoveryCoordinator.cs
+++ b/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/RecoveryCoordinator.cs
@@ -28,6 +28,16 @@ namespace WorkflowForge.Extensions.Persistence.Recovery
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// IMPORTANT: resume replays the workflow from operation index 0 — the foundry always runs
+        /// its full operation list. Completed operations are skipped ONLY by a
+        /// <c>PersistenceMiddleware</c> (from WorkflowForge.Extensions.Persistence) attached to the
+        /// foundry, which reloads the snapshot and short-circuits operations whose index is below the
+        /// snapshot's <c>NextOperationIndex</c>. The <paramref name="foundryFactory"/> MUST attach
+        /// that middleware (with the same persistence provider). Without it, every operation — including
+        /// ones that already completed and had side effects before the crash — is re-executed, which
+        /// can cause duplicate side effects (e.g. double-charging a payment).
+        /// </remarks>
         public async Task ResumeAsync(
             Func<IWorkflowFoundry> foundryFactory,
             Func<IWorkflow> workflowFactory,
@@ -50,7 +60,8 @@ namespace WorkflowForge.Extensions.Persistence.Recovery
                 foundry.Properties[kv.Key] = kv.Value;
             }
 
-            // Execute starting from NextOperationIndex (middleware will also skip as safety net)
+            // The foundry runs its full operation list; a PersistenceMiddleware attached by the
+            // foundryFactory is what skips operations already completed before the crash (see remarks).
             var smith = WorkflowForge.CreateSmith(foundry.Logger, foundry.ServiceProvider);
             foundry.SetCurrentWorkflow(workflow);
 

--- a/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/WorkflowForge.Extensions.Persistence.Recovery.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/WorkflowForge.Extensions.Persistence.Recovery.csproj
@@ -24,11 +24,7 @@
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
+    <!-- Version is centralized in src/Directory.Build.props -->
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../WorkflowForge.Extensions.Persistence/WorkflowForge.Extensions.Persistence.csproj" />
@@ -45,7 +41,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/WorkflowForge.Extensions.Persistence.Recovery.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Persistence.Recovery/WorkflowForge.Extensions.Persistence.Recovery.csproj
@@ -36,11 +36,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Persistence/PersistenceMiddleware.cs
+++ b/src/extensions/WorkflowForge.Extensions.Persistence/PersistenceMiddleware.cs
@@ -203,7 +203,12 @@ namespace WorkflowForge.Extensions.Persistence
 
         private static Guid DeterministicGuid(string input)
         {
-            using var sha1 = System.Security.Cryptography.SHA1.Create(); // NOSONAR - SHA1 used for deterministic GUID derivation, not for cryptographic security
+            // SHA1 is used purely to derive a stable GUID from a caller-supplied key string; it is
+            // NOT used for any security/cryptographic purpose. The algorithm must stay stable so
+            // persisted snapshot keys remain resolvable across versions, so it is intentionally SHA1.
+#pragma warning disable S4790 // "Use a stronger hashing algorithm" — not applicable, see above.
+            using var sha1 = System.Security.Cryptography.SHA1.Create();
+#pragma warning restore S4790
             var bytes = System.Text.Encoding.UTF8.GetBytes(input);
             var hash = sha1.ComputeHash(bytes);
             var guidBytes = new byte[16];

--- a/src/extensions/WorkflowForge.Extensions.Persistence/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Persistence/README.md
@@ -173,7 +173,7 @@ services.AddPersistenceConfiguration(configuration);
 var options = serviceProvider.GetRequiredService<IOptions<PersistenceOptions>>().Value;
 ```
 
-[Persistence configuration](../../../docs/core/configuration.md#persistence-extensions)
+[Persistence configuration](../../../docs/core/configuration.md#persistence-extension)
 
 ## Provider interface
 
@@ -193,7 +193,7 @@ public interface IWorkflowPersistenceProvider
 ## Links
 
 - [Getting Started](../../../docs/getting-started/getting-started.md)
-- [Configuration Guide](../../../docs/core/configuration.md#persistence-extensions)
+- [Configuration Guide](../../../docs/core/configuration.md#persistence-extension)
 - [Extensions Overview](../../../docs/extensions/index.md)
 - [Recovery Extension](../WorkflowForge.Extensions.Persistence.Recovery/README.md)
 - [Sample 18: Persistence](../../samples/WorkflowForge.Samples.BasicConsole/README.md)

--- a/src/extensions/WorkflowForge.Extensions.Persistence/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Persistence/README.md
@@ -90,7 +90,7 @@ When `InstanceId` and `WorkflowKey` are set, deterministic GUIDs are derived fro
 
 ## Key points
 
-- No default provider on purpose: stay storage-neutral and dependency-free.
+- No default provider on purpose: stay storage-neutral (you implement `IWorkflowPersistenceProvider`). Beyond core, depends only on `Microsoft.Extensions.*` for options/DI.
 - Checkpoints after each successful operation; resume skips completed steps via `NextOperationIndex`.
 - Optional stable keys tie executions to logical instances across restarts.
 - Middleware is written to be safe under concurrent workflows.

--- a/src/extensions/WorkflowForge.Extensions.Persistence/WorkflowForge.Extensions.Persistence.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Persistence/WorkflowForge.Extensions.Persistence.csproj
@@ -44,11 +44,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Persistence/WorkflowForge.Extensions.Persistence.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Persistence/WorkflowForge.Extensions.Persistence.csproj
@@ -22,7 +22,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
 
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -33,11 +32,7 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
+    <!-- Version is centralized in src/Directory.Build.props -->
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
@@ -54,7 +49,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Resilience.Polly/ILRepack.targets
+++ b/src/extensions/WorkflowForge.Extensions.Resilience.Polly/ILRepack.targets
@@ -23,4 +23,11 @@
     <Delete Files="$(OutputPath)Polly.dll" Condition="Exists('$(OutputPath)Polly.dll')" />
     <Delete Files="$(OutputPath)Polly.Core.dll" Condition="Exists('$(OutputPath)Polly.Core.dll')" />
   </Target>
+
+  <!-- Guard: ILRepack only runs in Release. Packing in any other configuration would produce a
+       package whose merged Polly assemblies were never merged in, causing runtime load failures.
+       Fail fast so a stray `dotnet pack` (Debug by default) cannot ship a broken package. -->
+  <Target Name="WorkflowForgeGuardReleasePack" BeforeTargets="Pack" Condition="!$(Configuration.Contains('Release'))">
+    <Error Text="WorkflowForge.Extensions.Resilience.Polly uses ILRepack, which only runs in Release. Pack with 'dotnet pack -c Release' to produce a valid package." />
+  </Target>
 </Project>

--- a/src/extensions/WorkflowForge.Extensions.Resilience.Polly/WorkflowForge.Extensions.Resilience.Polly.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Resilience.Polly/WorkflowForge.Extensions.Resilience.Polly.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly" Version="8.6.5" PrivateAssets="all" />
+    <PackageReference Include="Polly" Version="8.7.0" PrivateAssets="all" />
     <!--
       Polly is ILRepack-merged (PrivateAssets="all"), so its transitive dependencies are NOT
       written to this package's nuspec. The merged Polly.Core IL still references these BCL
@@ -50,14 +50,14 @@
       or consumers hit FileNotFoundException (e.g. Microsoft.Bcl.TimeProvider on .NET 8+).
       These are BCL polyfills and must NOT be ILRepacked (System.* type-identity conflicts).
     -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.10" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.46" PrivateAssets="all" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/extensions/WorkflowForge.Extensions.Resilience.Polly/WorkflowForge.Extensions.Resilience.Polly.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Resilience.Polly/WorkflowForge.Extensions.Resilience.Polly.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -25,7 +24,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -37,9 +35,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,12 +43,22 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
 
   <ItemGroup>
     <PackageReference Include="Polly" Version="8.6.5" PrivateAssets="all" />
+    <!--
+      Polly is ILRepack-merged (PrivateAssets="all"), so its transitive dependencies are NOT
+      written to this package's nuspec. The merged Polly.Core IL still references these BCL
+      assemblies at runtime, so they must be declared here as regular (flowing) dependencies
+      or consumers hit FileNotFoundException (e.g. Microsoft.Bcl.TimeProvider on .NET 8+).
+      These are BCL polyfills and must NOT be ILRepacked (System.* type-identity conflicts).
+    -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.44.1" PrivateAssets="all" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Resilience/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Resilience/README.md
@@ -1,6 +1,6 @@
 # WorkflowForge.Extensions.Resilience
 
-Wrap operations with retry decorators and small strategy classes (exponential, fixed, jittered). No third-party policy library: only WorkflowForge core.
+Wrap operations with retry decorators and small strategy classes (exponential, fixed, jittered). No third-party policy library (Polly-free) — just WorkflowForge core plus small BCL polyfills (`System.Threading.Tasks.Extensions`, `System.ComponentModel.Annotations`).
 
 [![NuGet](https://img.shields.io/nuget/v/WorkflowForge.Extensions.Resilience.svg)](https://www.nuget.org/packages/WorkflowForge.Extensions.Resilience/)
 
@@ -183,9 +183,9 @@ public interface IWorkflowResilienceStrategy
 
 ## When to use this package vs Polly
 
-**This package** fits when you want no extra dependencies and simple retry timing is enough.
+**This package** fits when you want to avoid a third-party policy library and simple retry timing is enough.
 
-**WorkflowForge.Extensions.Resilience.Polly** fits when you need circuit breakers, bulkheads, rate limits, or stacked policies. Polly is ILRepacked there; this package stays dependency-free.
+**WorkflowForge.Extensions.Resilience.Polly** fits when you need circuit breakers, bulkheads, rate limits, or stacked policies. Polly is ILRepacked there; this package pulls in no third-party policy library (only small BCL polyfills).
 
 ## Links
 

--- a/src/extensions/WorkflowForge.Extensions.Resilience/WorkflowForge.Extensions.Resilience.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Resilience/WorkflowForge.Extensions.Resilience.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -24,7 +23,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -34,9 +32,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
@@ -48,7 +43,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Validation/README.md
+++ b/src/extensions/WorkflowForge.Extensions.Validation/README.md
@@ -10,7 +10,7 @@ Run `System.ComponentModel.DataAnnotations` validation before each operation, us
 dotnet add package WorkflowForge.Extensions.Validation
 ```
 
-Targets .NET Standard 2.0 or later. Validation uses the BCL annotations assembly only.
+Targets .NET Standard 2.0. Validation uses BCL DataAnnotations plus `Microsoft.Extensions.*` (options/DI integration); no third-party validation library.
 
 ## Quick Start
 

--- a/src/extensions/WorkflowForge.Extensions.Validation/WorkflowForge.Extensions.Validation.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Validation/WorkflowForge.Extensions.Validation.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
-    <PackageVersion>2.1.1</PackageVersion>
+    <!-- Version is centralized in src/Directory.Build.props -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -28,7 +27,6 @@
     <RepositoryBranch>main</RepositoryBranch>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright © 2025 AnimatLabs</Copyright>
     
     <!-- NuGet Package Settings -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -38,9 +36,6 @@
     <!-- Documentation -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>
-v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore references. Added ConfigureAwait(false) to all await calls. Improved error handling and resource disposal.
-    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,7 +48,7 @@ v2.1.0: Updated for WorkflowForge v2.1.0 compatibility. Removed SupportsRestore 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/extensions/WorkflowForge.Extensions.Validation/WorkflowForge.Extensions.Validation.csproj
+++ b/src/extensions/WorkflowForge.Extensions.Validation/WorkflowForge.Extensions.Validation.csproj
@@ -43,11 +43,11 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/samples/WorkflowForge.Samples.BasicConsole/README.md
+++ b/src/samples/WorkflowForge.Samples.BasicConsole/README.md
@@ -1,6 +1,6 @@
 # WorkflowForge Basic Console samples
 
-Console menu for **WorkflowForge 2.1.1**. Run a single sample or queue them all.
+Console menu for **WorkflowForge 2.1.2**. Run a single sample or queue them all.
 
 ## Run
 

--- a/src/samples/WorkflowForge.Samples.BasicConsole/Samples/PerformanceMonitoringSample.cs
+++ b/src/samples/WorkflowForge.Samples.BasicConsole/Samples/PerformanceMonitoringSample.cs
@@ -53,8 +53,17 @@ public class PerformanceMonitoringSample : ISample
         if (stats != null)
         {
             Console.WriteLine($"   Total operations executed: {stats.TotalOperations}");
+            Console.WriteLine($"   Success rate: {stats.SuccessRate:P0}");
             Console.WriteLine($"   Average execution time: {stats.AverageDuration.TotalMilliseconds:F2}ms");
-            Console.WriteLine($"   Total memory allocated: {stats.TotalMemoryAllocated / (1024 * 1024):F2} MB");
+            Console.WriteLine($"   Operations per second: {stats.OperationsPerSecond:F1}");
+            Console.WriteLine($"   Total memory allocated: {stats.TotalMemoryAllocated / (1024.0 * 1024.0):F2} MB");
+
+            // Per-operation breakdown (demonstrates GetAllOperationStatistics)
+            Console.WriteLine("   Per-operation breakdown:");
+            foreach (var op in stats.GetAllOperationStatistics())
+            {
+                Console.WriteLine($"     - {op.OperationName}: {op.AverageExecutionTime.TotalMilliseconds:F2}ms avg, {op.SuccessRate:P0} success ({op.ExecutionCount}x)");
+            }
         }
         else
         {

--- a/src/samples/WorkflowForge.Samples.BasicConsole/WorkflowForge.Samples.BasicConsole.csproj
+++ b/src/samples/WorkflowForge.Samples.BasicConsole/WorkflowForge.Samples.BasicConsole.csproj
@@ -36,12 +36,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/WorkflowForge.Extensions.Audit.Tests/AuditExtensionsShould.cs
+++ b/tests/WorkflowForge.Extensions.Audit.Tests/AuditExtensionsShould.cs
@@ -116,6 +116,27 @@ namespace WorkflowForge.Extensions.Audit.Tests
         }
 
         [Fact]
+        public async Task UseCurrentWorkflowName_GivenWriteCustomAuditAsyncWithCurrentWorkflowSet()
+        {
+            var foundry = WF.WorkflowForge.CreateFoundry("Ignored");
+            var workflow = WF.WorkflowForge.CreateWorkflow("RealWorkflowName")
+                .AddOperation("Op", (f, ct) => Task.CompletedTask)
+                .Build();
+            foundry.SetCurrentWorkflow(workflow);
+
+            await foundry.WriteCustomAuditAsync(
+                _auditProvider,
+                "Op",
+                AuditEventType.Custom,
+                "Status");
+
+            Assert.Single(_auditProvider.Entries);
+            // The framework does not write the Workflow.Name property; the name must come from the
+            // live CurrentWorkflow on the foundry.
+            Assert.Equal("RealWorkflowName", _auditProvider.Entries[0].WorkflowName);
+        }
+
+        [Fact]
         public async Task ThrowArgumentException_GivenWriteCustomAuditAsyncWithWhitespaceOperationName()
         {
             await Assert.ThrowsAsync<ArgumentException>(() =>

--- a/tests/WorkflowForge.Extensions.Audit.Tests/WorkflowForge.Extensions.Audit.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Audit.Tests/WorkflowForge.Extensions.Audit.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/WorkflowForge.Extensions.DependencyInjection.Tests/WorkflowForge.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.DependencyInjection.Tests/WorkflowForge.Extensions.DependencyInjection.Tests.csproj
@@ -6,20 +6,20 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/core/WorkflowForge/WorkflowForge.csproj" />

--- a/tests/WorkflowForge.Extensions.Logging.Serilog.Tests/WorkflowForge.Extensions.Logging.Serilog.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Logging.Serilog.Tests/WorkflowForge.Extensions.Logging.Serilog.Tests.csproj
@@ -13,18 +13,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/WorkflowForge.Extensions.Observability.HealthChecks.Tests/WorkflowForge.Extensions.Observability.HealthChecks.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Observability.HealthChecks.Tests/WorkflowForge.Extensions.Observability.HealthChecks.Tests.csproj
@@ -13,13 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/WorkflowForge.Extensions.Observability.OpenTelemetry.Tests/WorkflowForge.Extensions.Observability.OpenTelemetry.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Observability.OpenTelemetry.Tests/WorkflowForge.Extensions.Observability.OpenTelemetry.Tests.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -42,12 +42,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/tests/WorkflowForge.Extensions.Observability.Performance.Tests/FoundryPerformanceStatisticsShould.cs
+++ b/tests/WorkflowForge.Extensions.Observability.Performance.Tests/FoundryPerformanceStatisticsShould.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WorkflowForge.Extensions.Observability.Performance.Tests;
+
+public class FoundryPerformanceStatisticsShould
+{
+    [Fact]
+    public void ReturnZeroDefaults_WhenNothingRecorded()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        Assert.Equal(0, stats.TotalOperations);
+        Assert.Equal(0, stats.SuccessfulOperations);
+        Assert.Equal(0, stats.FailedOperations);
+        Assert.Equal(0.0, stats.SuccessRate);
+        Assert.Equal(TimeSpan.Zero, stats.AverageDuration);
+        Assert.Equal(TimeSpan.Zero, stats.MinimumDuration);
+        Assert.Equal(TimeSpan.Zero, stats.MaximumDuration);
+        Assert.Equal(0, stats.TotalMemoryAllocated);
+        Assert.Equal(0, stats.AverageMemoryPerOperation);
+        Assert.Equal(0.0, stats.OperationsPerSecond);
+        Assert.True(stats.TotalDuration >= TimeSpan.Zero);
+        Assert.Empty(stats.GetAllOperationStatistics());
+        Assert.Null(stats.GetOperationStatistics("missing"));
+    }
+
+    [Fact]
+    public void AggregateCountsAndRates_AcrossMixedRecords()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        stats.Record("A", "id-a", TimeSpan.FromMilliseconds(10), success: true, memoryAllocated: 100);
+        stats.Record("B", "id-b", TimeSpan.FromMilliseconds(20), success: true, memoryAllocated: 200);
+        stats.Record("C", "id-c", TimeSpan.FromMilliseconds(30), success: false, memoryAllocated: 300);
+
+        Assert.Equal(3, stats.TotalOperations);
+        Assert.Equal(2, stats.SuccessfulOperations);
+        Assert.Equal(1, stats.FailedOperations);
+        Assert.Equal(2.0 / 3.0, stats.SuccessRate, 5);
+        Assert.Equal(TimeSpan.FromMilliseconds(20), stats.AverageDuration);
+        Assert.Equal(TimeSpan.FromMilliseconds(10), stats.MinimumDuration);
+        Assert.Equal(TimeSpan.FromMilliseconds(30), stats.MaximumDuration);
+        Assert.Equal(600, stats.TotalMemoryAllocated);
+        Assert.Equal(200, stats.AverageMemoryPerOperation);
+        Assert.Equal(3, stats.GetAllOperationStatistics().Count);
+    }
+
+    [Fact]
+    public void AggregatePerOperation_WhenSameOperationRecordedMultipleTimes()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        stats.Record("A", "id-a", TimeSpan.FromMilliseconds(10), success: true, memoryAllocated: 100);
+        stats.Record("A", "id-a", TimeSpan.FromMilliseconds(30), success: false, memoryAllocated: 300);
+        stats.Record("B", "id-b", TimeSpan.FromMilliseconds(50), success: true, memoryAllocated: 500);
+
+        Assert.Equal(2, stats.GetAllOperationStatistics().Count);
+
+        var a = stats.GetOperationStatistics("A");
+        Assert.NotNull(a);
+        Assert.Equal(2, a!.ExecutionCount);
+        Assert.Equal(1, a.SuccessfulExecutions);
+        Assert.Equal(1, a.FailedExecutions);
+        Assert.Equal(0.5, a.SuccessRate);
+        Assert.Equal(TimeSpan.FromMilliseconds(20), a.AverageExecutionTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(10), a.MinimumExecutionTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(30), a.MaximumExecutionTime);
+        Assert.Equal(400, a.TotalMemoryAllocated);
+        Assert.Equal(200, a.AverageMemoryPerExecution);
+
+        Assert.Null(stats.GetOperationStatistics("does-not-exist"));
+    }
+
+    [Fact]
+    public void ClampNegativeDurationAndMemory_ToZero()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        stats.Record("A", "id-a", TimeSpan.FromTicks(-100), success: true, memoryAllocated: -50);
+
+        Assert.Equal(1, stats.TotalOperations);
+        Assert.Equal(TimeSpan.Zero, stats.MinimumDuration);
+        Assert.Equal(TimeSpan.Zero, stats.MaximumDuration);
+        Assert.Equal(0, stats.TotalMemoryAllocated);
+    }
+
+    [Fact]
+    public void ThrowArgumentNullException_ForNullOperationNameOrId()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        Assert.Throws<ArgumentNullException>(() => stats.Record(null!, "id", TimeSpan.Zero, true, 0));
+        Assert.Throws<ArgumentNullException>(() => stats.Record("name", null!, TimeSpan.Zero, true, 0));
+        Assert.Throws<ArgumentNullException>(() => stats.GetOperationStatistics(null!));
+    }
+
+    [Fact]
+    public void RecordConsistently_UnderConcurrentAccess()
+    {
+        var stats = new FoundryPerformanceStatistics();
+
+        Parallel.For(0, 1000, i =>
+            stats.Record("Op", "id", TimeSpan.FromMilliseconds(1), success: i % 2 == 0, memoryAllocated: 10));
+
+        Assert.Equal(1000, stats.TotalOperations);
+        Assert.Equal(500, stats.SuccessfulOperations);
+        Assert.Equal(500, stats.FailedOperations);
+        Assert.Equal(10_000, stats.TotalMemoryAllocated);
+
+        var op = stats.GetOperationStatistics("Op");
+        Assert.NotNull(op);
+        Assert.Equal(1000, op!.ExecutionCount);
+    }
+}

--- a/tests/WorkflowForge.Extensions.Observability.Performance.Tests/OperationStatisticsShould.cs
+++ b/tests/WorkflowForge.Extensions.Observability.Performance.Tests/OperationStatisticsShould.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace WorkflowForge.Extensions.Observability.Performance.Tests;
+
+public class OperationStatisticsShould
+{
+    [Fact]
+    public void ExposeNameAndId_FromConstructor()
+    {
+        var stats = new OperationStatistics("MyOp", "op-id-1");
+
+        Assert.Equal("MyOp", stats.OperationName);
+        Assert.Equal("op-id-1", stats.OperationId);
+    }
+
+    [Fact]
+    public void ThrowArgumentNullException_ForNullNameOrId()
+    {
+        Assert.Throws<ArgumentNullException>(() => new OperationStatistics(null!, "id"));
+        Assert.Throws<ArgumentNullException>(() => new OperationStatistics("name", null!));
+    }
+
+    [Fact]
+    public void ReturnZeroDefaults_WhenNoExecutionsRecorded()
+    {
+        var stats = new OperationStatistics("MyOp", "op-id-1");
+
+        Assert.Equal(0, stats.ExecutionCount);
+        Assert.Equal(0, stats.SuccessfulExecutions);
+        Assert.Equal(0, stats.FailedExecutions);
+        Assert.Equal(0.0, stats.SuccessRate);
+        Assert.Equal(TimeSpan.Zero, stats.AverageExecutionTime);
+        Assert.Equal(TimeSpan.Zero, stats.MinimumExecutionTime);
+        Assert.Equal(TimeSpan.Zero, stats.MaximumExecutionTime);
+        Assert.Equal(0, stats.TotalMemoryAllocated);
+        Assert.Equal(0, stats.AverageMemoryPerExecution);
+    }
+}

--- a/tests/WorkflowForge.Extensions.Observability.Performance.Tests/PerformanceStatisticsMiddlewareShould.cs
+++ b/tests/WorkflowForge.Extensions.Observability.Performance.Tests/PerformanceStatisticsMiddlewareShould.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using WorkflowForge.Abstractions;
+
+namespace WorkflowForge.Extensions.Observability.Performance.Tests;
+
+public class PerformanceStatisticsMiddlewareShould
+{
+    private static IWorkflowOperation Operation() =>
+        Mock.Of<IWorkflowOperation>(o => o.Name == "Op" && o.Id == Guid.NewGuid());
+
+    [Fact]
+    public async Task RecordSuccess_UsingExplicitStatistics()
+    {
+        var stats = new FoundryPerformanceStatistics();
+        var middleware = new PerformanceStatisticsMiddleware(stats);
+        var foundry = Mock.Of<IWorkflowFoundry>();
+
+        var result = await middleware.ExecuteAsync(
+            Operation(), foundry, null, _ => Task.FromResult<object?>("result"));
+
+        Assert.Equal("result", result);
+        Assert.Equal(1, stats.TotalOperations);
+        Assert.Equal(1, stats.SuccessfulOperations);
+        Assert.Equal(0, stats.FailedOperations);
+    }
+
+    [Fact]
+    public async Task RecordFailureAndRethrow_WhenNextThrows()
+    {
+        var stats = new FoundryPerformanceStatistics();
+        var middleware = new PerformanceStatisticsMiddleware(stats);
+        var foundry = Mock.Of<IWorkflowFoundry>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            middleware.ExecuteAsync(Operation(), foundry, null,
+                _ => throw new InvalidOperationException("boom")));
+
+        Assert.Equal(1, stats.TotalOperations);
+        Assert.Equal(0, stats.SuccessfulOperations);
+        Assert.Equal(1, stats.FailedOperations);
+    }
+
+    [Fact]
+    public async Task PassThroughWithoutRecording_WhenNoStatisticsPresent()
+    {
+        var middleware = new PerformanceStatisticsMiddleware(); // resolves from properties
+        var foundry = Mock.Of<IWorkflowFoundry>(f => f.Properties == new ConcurrentDictionary<string, object?>());
+
+        var result = await middleware.ExecuteAsync(
+            Operation(), foundry, null, _ => Task.FromResult<object?>("passed"));
+
+        Assert.Equal("passed", result);
+    }
+
+    [Fact]
+    public async Task ResolveStatisticsFromFoundryProperties()
+    {
+        var stats = new FoundryPerformanceStatistics();
+        var properties = new ConcurrentDictionary<string, object?>();
+        properties["PerformanceStatistics"] = stats;
+        var middleware = new PerformanceStatisticsMiddleware();
+        var foundry = Mock.Of<IWorkflowFoundry>(f => f.Properties == properties);
+
+        await middleware.ExecuteAsync(Operation(), foundry, null, _ => Task.FromResult<object?>("ok"));
+
+        Assert.Equal(1, stats.TotalOperations);
+        Assert.Equal(1, stats.SuccessfulOperations);
+    }
+
+    [Fact]
+    public void ThrowArgumentNullException_ForNullStatisticsConstructor()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PerformanceStatisticsMiddleware(null!));
+    }
+
+    [Fact]
+    public async Task ThrowArgumentNullException_ForNullOperationOrNext()
+    {
+        var middleware = new PerformanceStatisticsMiddleware(new FoundryPerformanceStatistics());
+        var foundry = Mock.Of<IWorkflowFoundry>();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            middleware.ExecuteAsync(null!, foundry, null, _ => Task.FromResult<object?>(null)));
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            middleware.ExecuteAsync(Operation(), foundry, null, null!));
+    }
+}

--- a/tests/WorkflowForge.Extensions.Observability.Performance.Tests/WorkflowForge.Extensions.Observability.Performance.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Observability.Performance.Tests/WorkflowForge.Extensions.Observability.Performance.Tests.csproj
@@ -13,13 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/WorkflowForge.Extensions.Persistence.Tests/WorkflowForge.Extensions.Persistence.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Persistence.Tests/WorkflowForge.Extensions.Persistence.Tests.csproj
@@ -18,13 +18,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/tests/WorkflowForge.Extensions.Resilience.Polly.Tests/WorkflowForge.Extensions.Resilience.Polly.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Resilience.Polly.Tests/WorkflowForge.Extensions.Resilience.Polly.Tests.csproj
@@ -13,22 +13,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Polly" Version="8.6.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/WorkflowForge.Extensions.Resilience.Tests/WorkflowForge.Extensions.Resilience.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Resilience.Tests/WorkflowForge.Extensions.Resilience.Tests.csproj
@@ -13,13 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/WorkflowForge.Extensions.Validation.Tests/WorkflowForge.Extensions.Validation.Tests.csproj
+++ b/tests/WorkflowForge.Extensions.Validation.Tests/WorkflowForge.Extensions.Validation.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/WorkflowForge.Tests/ExtensionsTests/PerformanceTests/WorkflowFoundryPerformanceExtensionsShould.cs
+++ b/tests/WorkflowForge.Tests/ExtensionsTests/PerformanceTests/WorkflowFoundryPerformanceExtensionsShould.cs
@@ -213,5 +213,28 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
             Assert.NotNull(stats);
             Assert.Equal(1, stats!.TotalOperations);
         }
+
+        [Fact]
+        public async Task NotDoubleRegisterMiddleware_WhenEnabledConcurrently()
+        {
+            using var foundry = WorkflowForge.CreateFoundry("PerfConcurrentEnable");
+
+            // Hammer EnablePerformanceMonitoring from many threads; the middleware must register
+            // exactly once (a TOCTOU race would register it twice and double-count operations).
+            await Task.WhenAll(Enumerable.Range(0, 32)
+                .Select(_ => Task.Run(() => foundry.EnablePerformanceMonitoring())));
+
+            using var smith = WorkflowForge.CreateSmith();
+            var workflow = WorkflowForge.CreateWorkflow("PerfConcurrentEnable")
+                .AddOperation(new ActionWorkflowOperation("Only", (input, f, ct) => Task.CompletedTask))
+                .Build();
+
+            await smith.ForgeAsync(workflow, foundry);
+
+            var stats = foundry.GetPerformanceStatistics();
+            Assert.NotNull(stats);
+            // Would be 2+ if the middleware were registered more than once.
+            Assert.Equal(1, stats!.TotalOperations);
+        }
     }
 }

--- a/tests/WorkflowForge.Tests/ExtensionsTests/PerformanceTests/WorkflowFoundryPerformanceExtensionsShould.cs
+++ b/tests/WorkflowForge.Tests/ExtensionsTests/PerformanceTests/WorkflowFoundryPerformanceExtensionsShould.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using WorkflowForge.Abstractions;
 using WorkflowForge.Extensions.Observability.Performance;
 using WorkflowForge.Extensions.Observability.Performance.Abstractions;
+using WorkflowForge.Operations;
 using WorkflowForge.Testing;
 
 namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
@@ -20,6 +24,10 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
             _foundry.Dispose();
         }
 
+        // --------------------------------------------------------------------------------------
+        // Null-argument guards
+        // --------------------------------------------------------------------------------------
+
         [Fact]
         public void ThrowArgumentNullException_GivenNullFoundryForGetPerformanceStatistics()
         {
@@ -28,23 +36,28 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
         }
 
         [Fact]
+        public void ThrowArgumentNullException_GivenNullFoundryForEnablePerformanceMonitoring()
+        {
+            IWorkflowFoundry? foundry = null;
+            Assert.Throws<ArgumentNullException>(() => foundry!.EnablePerformanceMonitoring());
+        }
+
+        [Fact]
+        public void ThrowArgumentNullException_GivenNullFoundryForDisablePerformanceMonitoring()
+        {
+            IWorkflowFoundry? foundry = null;
+            Assert.Throws<ArgumentNullException>(() => foundry!.DisablePerformanceMonitoring());
+        }
+
+        // --------------------------------------------------------------------------------------
+        // GetPerformanceStatistics basics
+        // --------------------------------------------------------------------------------------
+
+        [Fact]
         public void ReturnNull_GivenPerformanceStatisticsNotSet()
         {
             var stats = _foundry.GetPerformanceStatistics();
             Assert.Null(stats);
-        }
-
-        [Fact]
-        public void ReturnStatistics_GivenPerformanceStatisticsStoredInProperties()
-        {
-            var statsMock = new Mock<IFoundryPerformanceStatistics>();
-            statsMock.Setup(s => s.TotalOperations).Returns(5);
-            _foundry.Properties["PerformanceStatistics"] = statsMock.Object;
-
-            var stats = _foundry.GetPerformanceStatistics();
-
-            Assert.NotNull(stats);
-            Assert.Equal(5, stats!.TotalOperations);
         }
 
         [Fact]
@@ -57,22 +70,43 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
             Assert.Null(stats);
         }
 
-        [Fact]
-        public void ThrowArgumentNullException_GivenNullFoundryForEnablePerformanceMonitoring()
-        {
-            IWorkflowFoundry? foundry = null;
-            Assert.Throws<ArgumentNullException>(() => foundry!.EnablePerformanceMonitoring());
-        }
+        // --------------------------------------------------------------------------------------
+        // Standard foundry: EnablePerformanceMonitoring now wires up real monitoring
+        // --------------------------------------------------------------------------------------
 
         [Fact]
-        public void ReturnFalse_GivenFoundryDoesNotImplementIPerformanceMonitoredFoundry()
+        public void ReturnTrueAndStoreStatistics_WhenEnabledOnStandardFoundry()
         {
             var result = _foundry.EnablePerformanceMonitoring();
-            Assert.False(result);
+
+            Assert.True(result);
+            Assert.NotNull(_foundry.GetPerformanceStatistics());
         }
 
         [Fact]
-        public void ReturnTrue_GivenFoundryImplementsIPerformanceMonitoredFoundry()
+        public void RemoveStatistics_WhenDisabledOnStandardFoundry()
+        {
+            _foundry.EnablePerformanceMonitoring();
+
+            var disabled = _foundry.DisablePerformanceMonitoring();
+
+            Assert.True(disabled);
+            Assert.Null(_foundry.GetPerformanceStatistics());
+        }
+
+        [Fact]
+        public void ReturnFalse_WhenDisablingMonitoringThatWasNeverEnabled()
+        {
+            var disabled = _foundry.DisablePerformanceMonitoring();
+            Assert.False(disabled);
+        }
+
+        // --------------------------------------------------------------------------------------
+        // Native IPerformanceMonitoredFoundry fast-path
+        // --------------------------------------------------------------------------------------
+
+        [Fact]
+        public void DelegateToNativeFoundry_ForEnable()
         {
             var mockFoundry = new Mock<IWorkflowFoundry>();
             var mockPerfFoundry = mockFoundry.As<IPerformanceMonitoredFoundry>();
@@ -85,21 +119,7 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
         }
 
         [Fact]
-        public void ThrowArgumentNullException_GivenNullFoundryForDisablePerformanceMonitoring()
-        {
-            IWorkflowFoundry? foundry = null;
-            Assert.Throws<ArgumentNullException>(() => foundry!.DisablePerformanceMonitoring());
-        }
-
-        [Fact]
-        public void ReturnFalse_GivenFoundryDoesNotImplementIPerformanceMonitoredFoundryForDisable()
-        {
-            var result = _foundry.DisablePerformanceMonitoring();
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void ReturnTrue_GivenFoundryImplementsIPerformanceMonitoredFoundryForDisable()
+        public void DelegateToNativeFoundry_ForDisable()
         {
             var mockFoundry = new Mock<IWorkflowFoundry>();
             var mockPerfFoundry = mockFoundry.As<IPerformanceMonitoredFoundry>();
@@ -109,6 +129,89 @@ namespace WorkflowForge.Tests.ExtensionsTests.PerformanceTests
 
             Assert.True(result);
             mockPerfFoundry.Verify(f => f.DisablePerformanceMonitoring(), Times.Once);
+        }
+
+        [Fact]
+        public void DelegateToNativeFoundry_ForGetStatistics()
+        {
+            var stats = new Mock<IFoundryPerformanceStatistics>().Object;
+            var mockFoundry = new Mock<IWorkflowFoundry>();
+            var mockPerfFoundry = mockFoundry.As<IPerformanceMonitoredFoundry>();
+            mockPerfFoundry.Setup(f => f.GetPerformanceStatistics()).Returns(stats);
+
+            var result = mockFoundry.Object.GetPerformanceStatistics();
+
+            Assert.Same(stats, result);
+            mockPerfFoundry.Verify(f => f.GetPerformanceStatistics(), Times.Once);
+        }
+
+        // --------------------------------------------------------------------------------------
+        // End-to-end through the real foundry + smith (the documented usage). This is the path the
+        // previous mock-injection tests never exercised, which is why the feature shipped broken.
+        // --------------------------------------------------------------------------------------
+
+        [Fact]
+        public async Task RecordStatistics_WhenWorkflowRunsThroughSmith()
+        {
+            using var foundry = WorkflowForge.CreateFoundry("PerfTest");
+            Assert.True(foundry.EnablePerformanceMonitoring());
+
+            using var smith = WorkflowForge.CreateSmith();
+            var workflow = WorkflowForge.CreateWorkflow("PerfTest")
+                .AddOperation(new ActionWorkflowOperation("A", (input, f, ct) => Task.CompletedTask))
+                .AddOperation(new ActionWorkflowOperation("B", (input, f, ct) => Task.CompletedTask))
+                .Build();
+
+            await smith.ForgeAsync(workflow, foundry);
+
+            var stats = foundry.GetPerformanceStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(2, stats!.TotalOperations);
+            Assert.Equal(2, stats.SuccessfulOperations);
+            Assert.Equal(0, stats.FailedOperations);
+            Assert.Equal(1.0, stats.SuccessRate);
+            Assert.Equal(2, stats.GetAllOperationStatistics().Count);
+            Assert.NotNull(stats.GetOperationStatistics("A"));
+        }
+
+        [Fact]
+        public async Task RecordFailure_WhenOperationThrows()
+        {
+            using var foundry = WorkflowForge.CreateFoundry("PerfFailTest");
+            foundry.EnablePerformanceMonitoring();
+
+            using var smith = WorkflowForge.CreateSmith();
+            var workflow = WorkflowForge.CreateWorkflow("PerfFailTest")
+                .AddOperation(new ActionWorkflowOperation("Ok", (input, f, ct) => Task.CompletedTask))
+                .AddOperation(new ActionWorkflowOperation("Boom", (input, f, ct) => throw new InvalidOperationException("boom")))
+                .Build();
+
+            await Assert.ThrowsAnyAsync<Exception>(() => smith.ForgeAsync(workflow, foundry));
+
+            var stats = foundry.GetPerformanceStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(2, stats!.TotalOperations);
+            Assert.Equal(1, stats.SuccessfulOperations);
+            Assert.Equal(1, stats.FailedOperations);
+        }
+
+        [Fact]
+        public async Task NotDoubleCount_WhenMonitoringEnabledTwice()
+        {
+            using var foundry = WorkflowForge.CreateFoundry("PerfIdempotentTest");
+            foundry.EnablePerformanceMonitoring();
+            foundry.EnablePerformanceMonitoring(); // must not register a second middleware
+
+            using var smith = WorkflowForge.CreateSmith();
+            var workflow = WorkflowForge.CreateWorkflow("PerfIdempotentTest")
+                .AddOperation(new ActionWorkflowOperation("Only", (input, f, ct) => Task.CompletedTask))
+                .Build();
+
+            await smith.ForgeAsync(workflow, foundry);
+
+            var stats = foundry.GetPerformanceStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(1, stats!.TotalOperations);
         }
     }
 }

--- a/tests/WorkflowForge.Tests/OrchestrationTests/WorkflowSmithBranchCoverageShould.cs
+++ b/tests/WorkflowForge.Tests/OrchestrationTests/WorkflowSmithBranchCoverageShould.cs
@@ -369,16 +369,20 @@ namespace WorkflowForge.Tests.OrchestrationTests
             using var smith = WorkflowForge.CreateSmith();
             var compensationTriggered = false;
             var compensationCompleted = false;
+            // Capture args and assert AFTER ForgeAsync: assertions inside event handlers are swallowed
+            // by the smith's subscriber-exception isolation and can never fail the test.
+            string? failedOperationName = null;
+            var successCount = -1;
 
             smith.CompensationTriggered += (_, args) =>
             {
                 compensationTriggered = true;
-                Assert.NotNull(args.FailedOperationName);
+                failedOperationName = args.FailedOperationName;
             };
             smith.CompensationCompleted += (_, args) =>
             {
                 compensationCompleted = true;
-                Assert.True(args.SuccessCount >= 0);
+                successCount = args.SuccessCount;
             };
 
             var workflow = WorkflowForge.CreateWorkflow($"CompEvents-{_uniqueTestId}")
@@ -390,6 +394,8 @@ namespace WorkflowForge.Tests.OrchestrationTests
 
             Assert.True(compensationTriggered);
             Assert.True(compensationCompleted);
+            Assert.NotNull(failedOperationName);
+            Assert.True(successCount >= 0);
         }
 
         [Fact]
@@ -415,16 +421,19 @@ namespace WorkflowForge.Tests.OrchestrationTests
             using var smith = WorkflowForge.CreateSmith();
             var restoreStarted = false;
             var restoreCompleted = false;
+            // Capture args and assert AFTER ForgeAsync (handler exceptions are isolated by the smith).
+            object? restoredOperation = null;
+            var restoreDuration = TimeSpan.FromSeconds(-1);
 
             smith.OperationRestoreStarted += (_, args) =>
             {
                 restoreStarted = true;
-                Assert.NotNull(args.Operation);
+                restoredOperation = args.Operation;
             };
             smith.OperationRestoreCompleted += (_, args) =>
             {
                 restoreCompleted = true;
-                Assert.True(args.Duration >= TimeSpan.Zero);
+                restoreDuration = args.Duration;
             };
 
             var workflow = WorkflowForge.CreateWorkflow($"RestoreEvents-{_uniqueTestId}")
@@ -436,6 +445,8 @@ namespace WorkflowForge.Tests.OrchestrationTests
 
             Assert.True(restoreStarted);
             Assert.True(restoreCompleted);
+            Assert.NotNull(restoredOperation);
+            Assert.True(restoreDuration >= TimeSpan.Zero);
         }
 
         [Fact]
@@ -513,11 +524,13 @@ namespace WorkflowForge.Tests.OrchestrationTests
 
             using var smith = WorkflowForge.CreateSmith(options: options);
             var restoreFailedEventRaised = false;
+            // Capture args and assert AFTER ForgeAsync (handler exceptions are isolated by the smith).
+            Exception? restoreException = null;
 
             smith.OperationRestoreFailed += (_, args) =>
             {
                 restoreFailedEventRaised = true;
-                Assert.NotNull(args.Exception);
+                restoreException = args.Exception;
             };
 
             var op1 = new BranchTestOperation("Op1",
@@ -536,6 +549,37 @@ namespace WorkflowForge.Tests.OrchestrationTests
             await Assert.ThrowsAsync<AggregateException>(() => smith.ForgeAsync(workflow));
 
             Assert.True(restoreFailedEventRaised);
+            Assert.NotNull(restoreException);
+        }
+
+        [Fact]
+        public async Task IsolateThrowingSubscribers_WithoutMaskingExceptionOrAbortingCompensation()
+        {
+            using var smith = WorkflowForge.CreateSmith();
+            var restored = false;
+
+            // Subscribers that throw must neither replace the workflow's real exception nor abort
+            // the compensation loop.
+            smith.WorkflowFailed += (_, _) => throw new InvalidOperationException("handler-should-be-isolated");
+            smith.OperationRestoreStarted += (_, _) => throw new InvalidOperationException("handler-should-be-isolated");
+
+            var op1 = new BranchTestOperation("Op1",
+                forge: () => Task.FromResult<object?>("one"),
+                restore: () => { restored = true; return Task.CompletedTask; });
+            var fail = new BranchTestOperation("Fail",
+                forge: () => throw new InvalidOperationException("real-failure"),
+                restore: () => Task.CompletedTask);
+
+            var workflow = WorkflowForge.CreateWorkflow($"IsolateSubs-{_uniqueTestId}")
+                .AddOperation(op1)
+                .AddOperation(fail)
+                .Build();
+
+            // The original operation exception propagates — NOT a subscriber's exception.
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => smith.ForgeAsync(workflow));
+            Assert.Equal("real-failure", ex.Message);
+            // Compensation still ran despite the throwing OperationRestoreStarted subscriber.
+            Assert.True(restored);
         }
 
         private sealed class BranchTestOperation : IWorkflowOperation

--- a/tests/WorkflowForge.Tests/OrchestrationTests/WorkflowSmithPoolShould.cs
+++ b/tests/WorkflowForge.Tests/OrchestrationTests/WorkflowSmithPoolShould.cs
@@ -37,6 +37,31 @@ namespace WorkflowForge.Tests.OrchestrationTests
         }
 
         [Fact]
+        public async Task NotLeakStalePropertiesAcrossPooledRuns_WhenSmallerWorkflowFails()
+        {
+            using var smith = WorkflowForge.CreateSmith();
+
+            // First run: a 3-operation workflow that completes, leaving LastCompletedIndex = 2 on the
+            // pooled foundry's Properties.
+            await smith.ForgeAsync(CreateNoOpWorkflow($"Leak-Big-{_uniqueTestId}", 3));
+
+            // Reuse the pooled foundry for a 1-operation workflow whose only op fails. If stale
+            // Properties leaked, compensation would walk from the stale index (2) and hit
+            // operations[2] on a 1-element list, throwing ArgumentOutOfRangeException and masking
+            // the operation's real exception.
+            var failing = new Workflow(
+                $"Leak-Small-{_uniqueTestId}",
+                "fails on its only operation",
+                "1.0.0",
+                new List<IWorkflowOperation> { new ThrowingOperation() },
+                new Dictionary<string, object?>());
+
+            var ex = await Record.ExceptionAsync(() => smith.ForgeAsync(failing));
+
+            Assert.IsType<InvalidOperationException>(ex);
+        }
+
+        [Fact]
         public async Task DrainPoolWithoutException_GivenDisposeAfterForgeAsync()
         {
             var smith = WorkflowForge.CreateSmith();
@@ -125,14 +150,36 @@ namespace WorkflowForge.Tests.OrchestrationTests
             Assert.Null(ex2);
         }
 
-        private static Workflow CreateNoOpWorkflow(string name)
+        private static Workflow CreateNoOpWorkflow(string name, int operationCount = 1)
         {
+            var operations = new List<IWorkflowOperation>();
+            for (var i = 0; i < operationCount; i++)
+            {
+                operations.Add(new NoOpOperation());
+            }
+
             return new Workflow(
                 name,
                 "Pool test workflow",
                 "1.0.0",
-                new List<IWorkflowOperation> { new NoOpOperation() },
+                operations,
                 new Dictionary<string, object?>());
+        }
+
+        private sealed class ThrowingOperation : IWorkflowOperation
+        {
+            public Guid Id { get; } = Guid.NewGuid();
+            public string Name => "Throwing";
+            public string? Description => null;
+
+            public Task<object?> ForgeAsync(object? inputData, IWorkflowFoundry foundry, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Intentional failure for pool-reuse test.");
+
+            public Task RestoreAsync(object? outputData, IWorkflowFoundry foundry, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+
+            public void Dispose()
+            { }
         }
 
         private sealed class NoOpOperation : IWorkflowOperation

--- a/tests/WorkflowForge.Tests/WorkflowForge.Tests.csproj
+++ b/tests/WorkflowForge.Tests/WorkflowForge.Tests.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/WorkflowForge.Tests/WorkflowFoundryShould.cs
+++ b/tests/WorkflowForge.Tests/WorkflowFoundryShould.cs
@@ -769,6 +769,24 @@ public class WorkflowFoundryShould
         Assert.True(operationExecuted);
     }
 
+    [Fact]
+    public async Task SurfaceOperationException_GivenOperationFailedHandlerThrows()
+    {
+        // Arrange: the operation fails AND the OperationFailed subscriber throws.
+        var foundry = CreateTestFoundry();
+
+        foundry.OperationFailed += (_, _) => throw new InvalidOperationException("failed-handler-error");
+        foundry.AddOperation(new DelegateWorkflowOperation<object, string>("Op1", (input, f, ct) =>
+            throw new InvalidOperationException("real-operation-error")));
+
+        // Act
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => foundry.ForgeAsync());
+
+        // Assert: the operation's real exception surfaces; the handler's exception is isolated.
+        Assert.Contains("real-operation-error", ex.ToString());
+        Assert.DoesNotContain("failed-handler-error", ex.ToString());
+    }
+
     #endregion Operation Management Tests
 
     #region Middleware Tests


### PR DESCRIPTION
## Summary

Multiple improvements and bug fixes

## Changes

- **Resilience.Polly**: declared Polly's transitive dependencies (`Microsoft.Bcl.TimeProvider`, `Microsoft.Bcl.AsyncInterfaces`, `System.ComponentModel.Annotations`, `System.Threading.Tasks.Extensions`, and the `Microsoft.Extensions.DependencyInjection`/`Configuration` abstractions) so they flow to consumers. Previously the ILRepack-merged Polly referenced `Microsoft.Bcl.TimeProvider` but it was never declared in the package, causing a runtime `FileNotFoundException` (e.g. calling `UsePollyComprehensive` on .NET 8+).
- **Observability.OpenTelemetry** and **Logging.Serilog**: fixed the same class of missing transitive dependency (`Microsoft.Extensions.*`, `System.Diagnostics.DiagnosticSource`, `System.Threading.Channels`) for their ILRepack-merged libraries.
- **Observability.Performance**: `EnablePerformanceMonitoring()` / `GetPerformanceStatistics()` now work on standard foundries. Added `FoundryPerformanceStatistics`, `OperationStatistics`, and `PerformanceStatisticsMiddleware`; previously the API was a no-op (it required an interface nothing implemented) and always returned `null`.
- **Core**: pooled foundries no longer leak `Properties` between executions; `WorkflowFoundry.Reset()` now clears per-execution state, preventing a stale operation index from crashing compensation on a subsequent (smaller) workflow.
- **Audit**: audit entries now record the real workflow name from the foundry's current workflow instead of always `"Unknown"`.
- **Core**: lifecycle-event subscribers throwing no longer mask the workflow's real exception or abort compensation mid-loop; `WorkflowSmith.Dispose()` iterates middleware under its lock; a check-then-act race that could leak a foundry on concurrent dispose is closed.
- Guarded the ILRepack extensions so packing outside `Release` fails fast instead of shipping an unmerged package.
- **Persistence**: suppressed the SonarAnalyzer `S4790` build error on the SHA1 used to derive snapshot keys (scoped `#pragma` with rationale); SHA1 here is a non-cryptographic key digest, and changing it would break existing persisted snapshot keys.
- Package version and shared package metadata (`Copyright`, `PackageReleaseNotes`) are centralized in `src/Directory.Build.props`; all packages release under one version. The release workflow now overrides both `Version` and `PackageVersion` so assembly and package versions stay in lockstep.
- Documentation corrected: performance-monitoring examples, false "dependency-free" claims on the Performance/Resilience extensions, and broken configuration-guide anchor links. Added `docs/RELEASING.md`.

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or documented in CHANGELOG)